### PR TITLE
Support scalafixDependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,9 @@ developers := List(
 resolvers += Resolver.sonatypeRepo("releases")
 libraryDependencies ++= List(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.4.201711221230-r",
+  // coursier-small provides a binary stable API around Coursier making sure that
+  // sbt-scalafix doesn't conflict with the user's installed version of sbt-coursier.
+  // Details: https://github.com/olafurpg/coursier-small
   "com.geirsson" %% "coursier-small" % "1.0.0-M4",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ developers := List(
 resolvers += Resolver.sonatypeRepo("releases")
 libraryDependencies ++= List(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.4.201711221230-r",
-  "com.geirsson" %% "coursier-small" % "1.0.0-M2",
+  "com.geirsson" %% "coursier-small" % "1.0.0-M4",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )
 

--- a/src/main/scala/scalafix/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixInterface.scala
@@ -1,7 +1,7 @@
 package scalafix.sbt
 
-import com.geirsson.coursiersmall._
 import java.net.URLClassLoader
+import java.nio.file.Path
 import scala.language.reflectiveCalls
 
 trait ScalafixInterface {
@@ -10,22 +10,7 @@ trait ScalafixInterface {
 
 object ScalafixInterface {
 
-  def classloadInstance(): ScalafixInterface = {
-    val dep = new Dependency(
-      "ch.epfl.scala",
-      s"scalafix-cli_${BuildInfo.scala212}",
-      BuildInfo.scalafix
-    )
-    val settings = new Settings()
-      .withDependencies(List(dep))
-      .withRepositories(
-        List(
-          Repository.MavenCentral,
-          Repository.SonatypeSnapshots,
-          Repository.Ivy2Local
-        )
-      )
-    val jars = CoursierSmall.fetch(settings)
+  def classloadInstance(jars: List[Path]): ScalafixInterface = {
     type Main = {
       def main(args: Array[String]): Unit
     }

--- a/src/sbt-test/sbt-scalafix/basic/.scalafix.conf
+++ b/src/sbt-test/sbt-scalafix/basic/.scalafix.conf
@@ -1,3 +1,4 @@
 rules = [
   ExplicitResultTypes
+  "class:fix.Examplescalafixrule_v1" // loaded via scalafixDependencies
 ]

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -5,6 +5,10 @@ inThisBuild(
       "org.scalameta" %% "testkit" % "4.0.0-M6" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
+    ),
+    scalafixDependencies := List(
+      // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
+      "com.geirsson" % "example-scalafix-rule_2.12" % "1.1.1"
     )
   )
 )

--- a/src/sbt-test/sbt-scalafix/basic/tests/src/test/scala/tests/CheckSuite.scala
+++ b/src/sbt-test/sbt-scalafix/basic/tests/src/test/scala/tests/CheckSuite.scala
@@ -17,6 +17,7 @@ class CheckSuite extends FunSuite with DiffAssertions {
         |object Example {
         |  implicit val str: _root_.java.util.Map.Entry[_root_.scala.Int, _root_.scala.Predef.String] = null.asInstanceOf[java.util.Map.Entry[Int, String]]
         |}
+        |// Hello world!
         |""".stripMargin
     assertNoDiff(obtained, expected)
   }

--- a/src/test/scala/scalafix/internal/sbt/ScalafixInterfaceSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixInterfaceSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.internal.sbt
 
 import org.scalatest.FunSuite
-import scalafix.sbt.ScalafixInterface
+import scalafix.sbt.ScalafixPlugin
 
 class ScalafixInterfaceSuite extends FunSuite {
-  test("classloadInstance") {
-    val cli = ScalafixInterface.classloadInstance()
+  test("ScalafixPlugin.cli") {
+    val Right(cli) = ScalafixPlugin.cli
     val e = intercept[Exception] {
       cli.main(Array("--foobar", "--no-sys-exit"))
     }


### PR DESCRIPTION
Fixes #7.

This PR improves support for custom rules that are published to Maven
Central. This functionality is required for rules like
scala-collection-compat. We do a best-effort to avoid redundant
dependency fetching of `scalafixDependencies` by caching the results
in an in-memory map. In the future, it would make sense to expose more
powerful APIs in scalafix to cache classloaders between invocations.