### PR TITLE
Throw FeedbackProvidedError to avoid redundant logs

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixFailed.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixFailed.scala
@@ -1,0 +1,8 @@
+package scalafix.sbt
+
+import sbt.FeedbackProvidedException
+import scalafix.interfaces.ScalafixError
+
+final class ScalafixFailed(val errors: List[ScalafixError])
+    extends RuntimeException(errors.mkString(" "))
+    with FeedbackProvidedException

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -336,7 +336,7 @@ object ScalafixPlugin extends AutoPlugin {
 
         val errors = api.runMain(mainArgs)
         if (errors.nonEmpty) {
-          throw new MessageOnlyException(errors.mkString(", "))
+          throw new ScalafixFailed(errors.toList)
         }
       }
     }


### PR DESCRIPTION
This makes th output from failed runs cleaner by eliminating redudant
lines. The change is particularly welcome when running aggregated tasks
across multiple projects

Before:
```
[error] TestError
[error] TestError
[error] (a/:sbtfixTest) TestError
[error] (b/:sbtfixTest) TestError
```

After:
```
[error] (a/sbtfixTest) TestError
[error] (b/sbtfixTest) TestError
```

Thanks @jvican for the help finding this.