### PR TITLE
Support binary cross versioned scalafixDependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ inThisBuild(
   List(
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
-      "com.geirsson" % "example-scalafix-rule_2.12" % "1.3.0"
+      "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
     )
   )
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 import sbt._
 
 object Dependencies {
+  val x = List(1) // scalafix:ok
   def scalafixVersion: String = sys.env.get("TRAVIS_TAG") match {
     case Some(v) if v.nonEmpty => v.stripPrefix("v")
     case _ => "0.6.0-M19"

--- a/src/main/scala/scalafix/internal/sbt/ScalafixCoursier.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCoursier.scala
@@ -43,7 +43,14 @@ object ScalafixCoursier {
     new function.Function[Seq[ModuleID], List[Path]] {
       override def apply(t: Seq[ModuleID]): List[Path] = {
         val dependencies = t.map { module =>
-          new Dependency(module.organization, module.name, module.revision)
+          val binarySuffix =
+            if (module.crossVersion == CrossVersion.binary) "_2.12"
+            else ""
+          new Dependency(
+            module.organization,
+            module.name + binarySuffix,
+            module.revision
+          )
         }
         CoursierSmall.fetch(
           fetchSettings.withDependencies(scalafixCli :: dependencies.toList)

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -8,7 +8,7 @@ inThisBuild(
     ),
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
-      "com.geirsson" % "example-scalafix-rule_2.12" % "1.3.0"
+      "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
     )
   )
 )

--- a/src/sbt-test/sbt-scalafix/inconfig/build.sbt
+++ b/src/sbt-test/sbt-scalafix/inconfig/build.sbt
@@ -8,7 +8,7 @@ inThisBuild(
     ),
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
-      "com.geirsson" % "example-scalafix-rule_2.12" % "1.3.0"
+      "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
     )
   )
 )

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -23,8 +23,10 @@ class SbtCompletionsSuite extends FunSuite {
   }
   git.tag("v0.1.0")
 
-  val exampleDependency =
-    sbt.ModuleID("com.geirsson", "example-scalafix-rule_2.12", "1.3.0")
+  val exampleDependency = {
+    import sbt._
+    "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
+  }
   val mainArgs =
     ScalafixInterface.fromToolClasspath(Seq(exampleDependency))().args
   val loadedRules = mainArgs.availableRules.asScala.toList

--- a/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
@@ -25,9 +25,7 @@ class ScalafixAPISuite extends FunSuite {
     val baos = new ByteArrayOutputStream()
     val logger = Compat.ConsoleLogger(new PrintStream(baos))
     val ScalafixInterface(_, args) = ScalafixInterface.fromToolClasspath(
-      List(
-        "com.geirsson" % "example-scalafix-rule_2.12" % "1.3.0"
-      ),
+      List("com.geirsson" %% "example-scalafix-rule" % "1.3.0"),
       logger
     )()
     val tmp = Files.createTempFile("scalafix", "Tmp.scala")


### PR DESCRIPTION
This avoids the pesky `_2.12` suffix.