### PR TITLE
Skip validation if there are no sources to fix.

### DIFF
--- a/src/sbt-test/sbt-scalafix/root-validation/build.sbt
+++ b/src/sbt-test/sbt-scalafix/root-validation/build.sbt
@@ -1,0 +1,20 @@
+inThisBuild(
+  List(
+    scalaVersion := "2.12.6",
+  )
+)
+
+lazy val root = project
+  .in(file("."))
+  .aggregate(lib)
+
+lazy val lib = project
+  .in(file("lib"))
+  .settings(
+    addCompilerPlugin(scalafixSemanticdb),
+    scalacOptions ++= List(
+      "-Ywarn-unused",
+      "-Yrangepos"
+    )
+  )
+

--- a/src/sbt-test/sbt-scalafix/root-validation/build.sbt
+++ b/src/sbt-test/sbt-scalafix/root-validation/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion := "2.12.6",
+    scalaVersion := "2.12.6"
   )
 )
 
@@ -17,4 +17,3 @@ lazy val lib = project
       "-Yrangepos"
     )
   )
-

--- a/src/sbt-test/sbt-scalafix/root-validation/lib/src/main/scala/lib/App.scala
+++ b/src/sbt-test/sbt-scalafix/root-validation/lib/src/main/scala/lib/App.scala
@@ -1,0 +1,6 @@
+package lib
+
+import scala.concurrent.Future
+import scala.util.Success
+
+object App { println(Success(1)) }

--- a/src/sbt-test/sbt-scalafix/root-validation/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/root-validation/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/root-validation/project/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/root-validation/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")

--- a/src/sbt-test/sbt-scalafix/root-validation/test
+++ b/src/sbt-test/sbt-scalafix/root-validation/test
@@ -1,0 +1,3 @@
+-> root/scalafix --check RemoveUnused
+> root/scalafix RemoveUnused
+> root/scalafix --check RemoveUnused


### PR DESCRIPTION
Previously, the semanticdb-scalac and scalacOptions validation ran for
empty root projects with no sources, failing the build when running
scalafix from the root project.  Since there are no sources to fix we
should not run any validation.

Fixes https://github.com/scalacenter/scalafix/issues/884