### PR TITLE
Support one-line syntax for running published rules

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Xss4m
+-Xms1G
+-Xmx4G
+-XX:ReservedCodeCacheSize=1024m
+-XX:+TieredCompilation
+-XX:+CMSClassUnloadingEnabled
+-Dfile.encoding=UTF-8

--- a/src/main/scala/scalafix/internal/sbt/DependencyRule.scala
+++ b/src/main/scala/scalafix/internal/sbt/DependencyRule.scala
@@ -1,0 +1,16 @@
+package scalafix.internal.sbt
+
+import sbt.ModuleID
+import scala.util.matching.Regex
+
+case class DependencyRule(
+    ruleName: String,
+    dependency: ModuleID
+)
+
+object DependencyRule {
+  lazy val Parsed: Regex =
+    "dependency:(.+)@(.+):(.+):(.+)".r
+  def format: String =
+    "dependency:$RULE_NAME@$ORGANIZATION:$ARTIFACT_NAME:$VERSION"
+}

--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -156,6 +156,7 @@ class ScalafixCompletions(
         uri("class") |
         uri("replace") |
         uri("github") |
+        uri("dependency") |
         namedRule2
     val shellArg: Parser[ShellArg] =
       rules | shellBase

--- a/src/main/scala/scalafix/sbt/BuildInfo.scala
+++ b/src/main/scala/scalafix/sbt/BuildInfo.scala
@@ -5,15 +5,15 @@ import java.util.Properties
 object BuildInfo {
 
   def scalafixVersion: String =
-    props.getProperty("scalafixVersion", "0.6.0-M17")
+    props.getProperty("scalafixVersion", "0.9.0")
   def scalafixStableVersion: String =
-    props.getProperty("scalafixStableVersion", "0.5.10")
+    props.getProperty("scalafixStableVersion", "0.9.0")
   def scalametaVersion: String =
-    props.getProperty("scalametaVersion", "4.0.0-M10")
+    props.getProperty("scalametaVersion", "4.1.0")
   def scala212: String =
-    props.getProperty("scala212", "2.12.6")
+    props.getProperty("scala212", "2.12.7")
   def scala211: String =
-    props.getProperty("scala211", "2.11.11")
+    props.getProperty("scala211", "2.11.12")
   def supportedScalaVersions: List[String] =
     List(scala212, scala211)
 

--- a/src/sbt-test/sbt-scalafix/dependency/.scalafix.conf
+++ b/src/sbt-test/sbt-scalafix/dependency/.scalafix.conf
@@ -1,0 +1,8 @@
+rules = [
+  RemoveUnused
+  ExplicitResultTypes
+  DisableSyntax
+  "class:fix.Examplescalafixrule_v1" // loaded via scalafixDependencies
+]
+
+DisableSyntax.noSemicolons = true

--- a/src/sbt-test/sbt-scalafix/dependency/build.sbt
+++ b/src/sbt-test/sbt-scalafix/dependency/build.sbt
@@ -1,0 +1,6 @@
+scalaVersion := "2.12.7"
+
+TaskKey[Unit]("check") := {
+  val text = IO.read(sourceDirectory.in(Compile).value / "scala" / "A.scala")
+  assert(text.contains("// v1 SemanticRule!"), text)
+}

--- a/src/sbt-test/sbt-scalafix/dependency/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/dependency/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.sonatypeRepo("releases")
+libraryDependencies += "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/dependency/project/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/dependency/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M6")

--- a/src/sbt-test/sbt-scalafix/dependency/src/main/scala/A.scala
+++ b/src/sbt-test/sbt-scalafix/dependency/src/main/scala/A.scala
@@ -1,0 +1,1 @@
+object A

--- a/src/sbt-test/sbt-scalafix/dependency/test
+++ b/src/sbt-test/sbt-scalafix/dependency/test
@@ -1,0 +1,3 @@
+> scalafixEnable
+> scalafix dependency:SemanticRule@com.geirsson:example-scalafix-rule:1.3.0
+> check

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -97,6 +97,7 @@ class SbtCompletionsSuite extends FunSuite {
          |SemanticRule
          |SyntacticRule
          |class:
+         |dependency:
          |file:
          |github:
          |replace:


### PR DESCRIPTION
To run a published rule directly from the sbt shell without modifying
build.sbt:
```
> scalafix dependency:SemanticRule@com.geirsson:example-scalafix-rule:1.3.0
```