### PR TITLE
Use lazy val instead of def

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -72,10 +72,10 @@ object ScalafixPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(Compile, Test).flatMap(c => inConfig(c)(scalafixConfigSettings(c)))
 
-  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+  override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
     initialize := {
       val _ = initialize.value
       // Ideally, we would not resort to storing mutable state in `initialize`.


### PR DESCRIPTION
The projectSettings definition takes about 150ms to run on my laptop
during akka startup. It gets evaluated for each subproject in the build
which adds up. After this change, I found that the average time to load
akka dropped from roughly 19 seconds to 15.5 seconds.