### PR TITLE
Migrate from coursier-small to coursier:interface

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.0.1"
 project.git=true
 align=none
 assumeStandardLibraryStripMargin = true

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
     // coursier-small provides a binary stable API around Coursier making sure that
     // sbt-scalafix doesn't conflict with the user's installed version of sbt-coursier.
     // Details: https://github.com/olafurpg/coursier-small
-    "com.geirsson" %% "coursier-small" % "1.3.3"
+    "com.geirsson" %% "coursier-small" % "1.3.3",
+    "io.get-coursier" % "interface" % "0.0.12"
   )
 }


### PR DESCRIPTION
The coursier-small module was created before the official
coursier/interface module was available. They both have the same goal,
expose a stable, zero dependency, API for fetching dependencies.  The
official API has the benefit of playing nicely with the official
coursier libraries when running concurrently.

The coursier/interface API is also richer, it for example supports
credentials, which is necessary to fix
https://github.com/scalacenter/scalafix/issues/984

We can't fully get rid of coursier-small yet since we use its types  in
the public API of sbt-scalafix. We should ideally deprecate the
coursier-small based settings down the road.