### PR TITLE
become compatible with sbt semanticdbEnabled settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
     - env: TEST="sbt 1.2"
       script: sbt ++2.12.8 test scripted
     - env: TEST="sbt 0.13"
-      script: sbt ++2.10.7 test scripted
+      script: sbt ++2.10.7 test "scripted sbt-scalafix/*"
 
 cache:
   directories:

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -217,7 +217,7 @@ object ScalafixPlugin extends AutoPlugin {
       shellArgs: ShellArgs,
       config: Configuration
   ): Def.Initialize[Task[Unit]] = Def.taskDyn {
-    val dependencies = libraryDependencies.value
+    val dependencies = allDependencies.value
     val files = filesToFix(shellArgs, config).value
     val withScalaArgs = mainArgs
       .withScalaVersion(scalaVersion.value)

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/.scalafix.conf
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  RemoveUnused
+]

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/build.sbt
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/build.sbt
@@ -1,0 +1,13 @@
+inThisBuild(
+  List(
+    scalaVersion := "2.12.11",
+    semanticdbEnabled := true,
+    semanticdbIncludeInJar := true,
+    semanticdbVersion := scalafixSemanticdb.revision
+  )
+)
+
+lazy val example = project
+  .settings(
+    scalacOptions += "-Ywarn-unused"
+  )

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/example/src/main/scala/example/Example.scala
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/example/src/main/scala/example/Example.scala
@@ -1,0 +1,11 @@
+package example
+
+import java.util.Map
+
+object Example {
+  private val a = 1
+  def f(): Unit = {
+    val b = ""
+    println("f")
+  }
+}

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/project/build.properties
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.9

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/test
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/test
@@ -1,0 +1,3 @@
+-> example/scalafix --check
+> example/scalafix
+> example/scalafix --check


### PR DESCRIPTION
This PullRequest makes SemanticRules work through `semanticdbEnabled` settings which are [introduced in sbt 1.3](https://github.com/sbt/sbt/pull/4410).

With this change, Scalafix users will get the following benefits:

- Being able to add SemanticDB settings in `ThisBuild` scope. (In some cases, it would be handy.)
- Re-using SemanticDB settings of another tools, for sbt-scalafix as well. (It seems to be an expected use case of `semanticdbEnabled` key.)

## Note
While I adds sbt 1.3.x specific scripted test, it seems not to be invoked in sbt 0.13 scenario.
I believe its test is only for sbt 1.3 and can be ignored in sbt 0.13 case. If not, please let me know.