### PR TITLE
Add ThisBuild recommendation settings to error message

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/SemanticRuleValidator.scala
+++ b/src/main/scala/scalafix/internal/sbt/SemanticRuleValidator.scala
@@ -1,4 +1,4 @@
-package scalafix.sbt
+package scalafix.internal.sbt
 
 import java.nio.file.Path
 
@@ -7,7 +7,7 @@ import scalafix.interfaces.ScalafixArguments
 
 import scala.collection.mutable.ListBuffer
 
-private[sbt] class SemanticRuleValidator(ifNotFound: => SemanticdbNotFound) {
+class SemanticRuleValidator(ifNotFound: SemanticdbNotFound) {
   def findErrors(
       files: Seq[Path],
       dependencies: Seq[ModuleID],
@@ -28,7 +28,7 @@ private[sbt] class SemanticRuleValidator(ifNotFound: => SemanticdbNotFound) {
   }
 }
 
-private[sbt] class SemanticdbNotFound(
+class SemanticdbNotFound(
     ruleNames: Seq[String],
     scalaVersion: String,
     sbtVersion: String

--- a/src/main/scala/scalafix/sbt/SemanticRuleValidator.scala
+++ b/src/main/scala/scalafix/sbt/SemanticRuleValidator.scala
@@ -2,7 +2,7 @@ package scalafix.sbt
 
 import java.nio.file.Path
 
-import sbt.librarymanagement.{CrossVersion, ModuleID}
+import sbt.{CrossVersion, ModuleID}
 import scalafix.interfaces.ScalafixArguments
 
 import scala.collection.mutable.ListBuffer

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/build.sbt
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/build.sbt
@@ -2,7 +2,6 @@ inThisBuild(
   List(
     scalaVersion := "2.12.11",
     semanticdbEnabled := true,
-    semanticdbIncludeInJar := true,
     semanticdbVersion := scalafixSemanticdb.revision
   )
 )


### PR DESCRIPTION
Following up of #89 , https://github.com/scalacenter/scalafix/pull/1094

Based on [this discussion](https://github.com/scalacenter/scalafix/pull/1094#discussion_r408247753), this PullRequest changes missing SemanticDB error message to ThisBuild configuration example if user sbt version is 1.3 or above.