### PR TITLE
Improve parser UX

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -138,9 +138,13 @@ class ScalafixCompletions(
     val keyOnlyArg: ArgP = {
       val flags = Seq(
         "--auto-suppress-linter-errors",
+        "--check",
         "--diff",
         "--help",
-        "--verbose"
+        "--stdout",
+        "--syntactic",
+        "--verbose",
+        "--version"
       ).map(literal)
       Parser.oneOf(flags) |
         hide(string) // catch-all for all args not known to sbt-scalafix

--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -17,7 +17,7 @@ class ScalafixCompletions(
   private type P = Parser[String]
   private type ArgP = Parser[ShellArgs.Arg]
 
-  private val equal: P = token("=").map(_.toString)
+  private val equal: P = token("=").examples("=")
   private val string: P = StringBasic
   private def argKey(key: String): P =
     key <~ equal

--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -18,7 +18,7 @@ class ScalafixCompletions(
   private type ArgP = Parser[ShellArgs.Arg]
   private type KVArgP = Parser[ArgP] // nested parser allows to match the key only
 
-  private val equal: P = token("=").examples("=")
+  private val sep: P = token("=" | " ").examples("=")
   private val string: P = StringBasic
   private def valueAfterKey(
       key: String,
@@ -27,7 +27,7 @@ class ScalafixCompletions(
       valueParser: ArgP
   ): KVArgP = {
     val keyParser = Parser.oneOf((key +: keyAliases).map(literal)).examples(key)
-    val sepValueParser = (equal ~> valueParser).!!!("missing or invalid value")
+    val sepValueParser = (sep ~> valueParser).!!!("missing or invalid value")
     keyParser.^^^(sepValueParser)
   }
 

--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -161,9 +161,11 @@ class ScalafixCompletions(
       val files: KVArgP = valueAfterKey("--files", "-f") {
         pathParser.map(v => ShellArgs.File(v.toString))
       }
+      val rules: KVArgP = valueAfterKey("--rules", "-r")(rule)
 
       diffBase |
-        files
+        files |
+        rules
     }
 
     val shellArg: ArgP =

--- a/src/main/scala/scalafix/internal/sbt/ShellArgs.scala
+++ b/src/main/scala/scalafix/internal/sbt/ShellArgs.scala
@@ -21,7 +21,7 @@ object ShellArgs {
 }
 
 case class ShellArgs(
-    rules: List[String],
-    files: List[String],
-    extra: List[String]
+    rules: List[String] = Nil,
+    files: List[String] = Nil,
+    extra: List[String] = Nil
 )

--- a/src/main/scala/scalafix/internal/sbt/ShellArgs.scala
+++ b/src/main/scala/scalafix/internal/sbt/ShellArgs.scala
@@ -1,33 +1,27 @@
 package scalafix.internal.sbt
 
 object ShellArgs {
-  def apply(args: Seq[ShellArg]): ShellArgs = {
+
+  sealed abstract class Arg
+  case class Rule(value: String) extends Arg
+  case class File(value: String) extends Arg
+  case class Extra(key: String, value: Option[String] = None) extends Arg
+
+  def apply(args: Seq[Arg]): ShellArgs = {
     val rules = List.newBuilder[String]
+    val files = List.newBuilder[String]
     val extra = List.newBuilder[String]
     args.foreach {
-      case x: Rule => rules += x.rule
-      case x: Extra => extra += x.value
+      case x: Rule => rules += x.value
+      case x: File => files += x.value
+      case x: Extra => extra += x.value.foldLeft(x.key)((k, v) => s"$k=$v")
     }
-    ShellArgs(rules.result(), extra.result())
+    ShellArgs(rules.result(), files.result(), extra.result())
   }
 }
 
 case class ShellArgs(
     rules: List[String],
+    files: List[String],
     extra: List[String]
-) {
-  private val filesArgsPrefixes = Seq("-f=", "--files=")
-
-  lazy val explicitFiles: List[String] =
-    extra.flatMap { e =>
-      filesArgsPrefixes.collectFirst {
-        case prefix if e.startsWith(prefix) =>
-          e.stripPrefix(prefix)
-      }
-    }
-
-}
-
-sealed abstract class ShellArg
-case class Rule(rule: String) extends ShellArg
-case class Extra(value: String) extends ShellArg
+)

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -255,9 +255,9 @@ object ScalafixPlugin extends AutoPlugin {
   ): Def.Initialize[Task[Seq[Path]]] =
     Def.taskDyn {
       // Dynamic task to avoid redundantly computing `unmanagedSources.value`
-      if (shellArgs.explicitFiles.nonEmpty) {
+      if (shellArgs.files.nonEmpty) {
         Def.task {
-          shellArgs.explicitFiles.map(file(_).toPath)
+          shellArgs.files.map(file(_).toPath)
         }
       } else {
         Def.task {

--- a/src/sbt-test/sbt-scalafix/explicit-files/test
+++ b/src/sbt-test/sbt-scalafix/explicit-files/test
@@ -9,3 +9,6 @@
 
 > scalafix -f=explicit/src/main/scala/OK.scala
 > scalafix --files=explicit/src/main/scala/OK.scala
+
+> scalafix -f explicit/src/main/scala/OK.scala
+> scalafix --files explicit/src/main/scala/OK.scala

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -80,12 +80,16 @@ class SbtCompletionsSuite extends AnyFunSuite {
     val obtained = displays.mkString("\n").trim
     val expected =
       """|--auto-suppress-linter-errors
+         |--check
          |--diff
          |--diff-base=
          |--files=
          |--help
          |--rules=
+         |--stdout
+         |--syntactic
          |--verbose
+         |--version
          |DisableSyntax
          |  Reports an error for disabled features such as var or XML literals.
          |ExplicitResultTypes

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -80,8 +80,8 @@ class SbtCompletionsSuite extends AnyFunSuite {
     val expected =
       """|--auto-suppress-linter-errors
          |--diff
-         |--diff-base
-         |--files
+         |--diff-base=
+         |--files=
          |--help
          |--verbose
          |DisableSyntax
@@ -115,6 +115,10 @@ class SbtCompletionsSuite extends AnyFunSuite {
       println("   |\"\"\"")
       fail("obtained != expected")
     }
+  }
+
+  checkCompletion("--fil") { (appends, _) =>
+    assert(appends == Seq("es="))
   }
 
   checkCompletion("--diff-base=", SkipWindows) { (appends, displays) =>

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -122,6 +122,12 @@ class SbtCompletionsSuite extends AnyFunSuite {
     assert(appends == Seq("es="))
   }
 
+  // only provide values suggestion after the key of a key/value arg
+  checkCompletion("--diff-base ") { (appends, _) =>
+    assert(appends.nonEmpty)
+    assert(!appends.contains("--help"))
+  }
+
   checkCompletion("--diff-base=", SkipWindows) { (appends, displays) =>
     // branches
     assert(displays.contains("master"))
@@ -153,6 +159,12 @@ class SbtCompletionsSuite extends AnyFunSuite {
     assert(args == Right(ShellArgs(extra = List("--bash"))))
   }
 
+  checkArgs("--files --test") { args =>
+    assert(args == Left("""missing or invalid value
+                          | --files --test
+                          |               ^""".stripMargin))
+  }
+
   checkArgs("--test --rules=Foo --files=NotHere", SkipWindows) { args =>
     assert(args == Left("""--files=NotHere
                           |missing or invalid value
@@ -168,10 +180,9 @@ class SbtCompletionsSuite extends AnyFunSuite {
   }
 
   checkArgs("--test  -f --rules=Foo", SkipWindows) { args =>
-    assert(args == Left("""Expected non-whitespace character
-                          |missing or invalid value
+    assert(args == Left("""missing or invalid value
                           | --test  -f --rules=Foo
-                          |           ^""".stripMargin))
+                          |                       ^""".stripMargin))
   }
 
   checkArgs("--test --rules=Foo -f", SkipWindows) { args =>

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -62,13 +62,13 @@ class SbtCompletionsSuite extends AnyFunSuite {
     }
   }
 
-  def checkArgs(name: String)(assertArgs: Seq[String] => Unit): Unit = {
+  def checkArgs(
+      name: String
+  )(assertArgs: Either[String, ShellArgs] => Unit): Unit = {
     test(name) {
       val input = name
-      val args = Parser.parse(" " + input, parser).right.get
-      val asStrings =
-        args.rules.flatMap(r => "-r" :: r :: Nil) ++ args.extra
-      assertArgs(asStrings)
+      val args = Parser.parse(" " + input, parser)
+      assertArgs(args)
     }
   }
 
@@ -144,11 +144,12 @@ class SbtCompletionsSuite extends AnyFunSuite {
 
   // shortcut for --rules
   checkArgs("ProcedureSyntax") { args =>
-    assert(args == Seq("-r", "ProcedureSyntax"))
+    assert(args == Right(ShellArgs(rules = List("ProcedureSyntax"))))
   }
 
   // consume extra
   checkArgs("--bash") { args =>
-    assert(args == Seq("--bash"))
+    assert(args == Right(ShellArgs(extra = List("--bash"))))
   }
+
 }

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -63,9 +63,10 @@ class SbtCompletionsSuite extends AnyFunSuite {
   }
 
   def checkArgs(
-      name: String
+      name: String,
+      testTags: Tag*
   )(assertArgs: Either[String, ShellArgs] => Unit): Unit = {
-    test(name) {
+    test(name, testTags: _*) {
       val input = name
       val args = Parser.parse(" " + input, parser)
       assertArgs(args)
@@ -150,6 +151,34 @@ class SbtCompletionsSuite extends AnyFunSuite {
   // consume extra
   checkArgs("--bash") { args =>
     assert(args == Right(ShellArgs(extra = List("--bash"))))
+  }
+
+  checkArgs("--test --rules=Foo --files=NotHere", SkipWindows) { args =>
+    assert(args == Left("""--files=NotHere
+                          |missing or invalid value
+                          | --test --rules=Foo --files=NotHere
+                          |                                   ^""".stripMargin))
+  }
+
+  checkArgs("--test  -f= --rules=Foo", SkipWindows) { args =>
+    assert(args == Left("""Expected non-whitespace character
+                          |missing or invalid value
+                          | --test  -f= --rules=Foo
+                          |            ^""".stripMargin))
+  }
+
+  checkArgs("--test  -f --rules=Foo", SkipWindows) { args =>
+    assert(args == Left("""Expected non-whitespace character
+                          |missing or invalid value
+                          | --test  -f --rules=Foo
+                          |           ^""".stripMargin))
+  }
+
+  checkArgs("--test --rules=Foo -f", SkipWindows) { args =>
+    assert(args == Left("""-f
+                          |missing or invalid value
+                          | --test --rules=Foo -f
+                          |                      ^""".stripMargin))
   }
 
 }

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -84,6 +84,7 @@ class SbtCompletionsSuite extends AnyFunSuite {
          |--diff-base=
          |--files=
          |--help
+         |--rules=
          |--verbose
          |DisableSyntax
          |  Reports an error for disabled features such as var or XML literals.
@@ -141,6 +142,12 @@ class SbtCompletionsSuite extends AnyFunSuite {
         assert(isSha1(append))
         assert(display.endsWith("ago)"))
     }
+  }
+
+  checkCompletion("-r=") { (appends, _) =>
+    assert(appends.contains("DisableSyntax"))
+    assert(appends.contains("class:"))
+    assert(!appends.contains("--help"))
   }
 
   checkCompletion("--rules file:bar/../", SkipWindows) { (appends, displays) =>


### PR DESCRIPTION
The first time I used scalafix, it was through sbt, and I struggled to get it work on the shell while looking at https://scalacenter.github.io/scalafix/docs/users/installation.html#help.

The biggest frustration was the weird behavior or `rules` (the sbt section does advertize the use of the key/prefix-less syntax, but I missed it as I focused on the `man`-like help rather than the tutorial):
```
[root] $ scalafix --rules A --rules B
[error] (Compile / scalafix) scalafix.sbt.InvalidArgument: Unknown rule '--rules'
```
```
[root] $ scalafix --rules A B
[error] (Compile / scalafix) scalafix.sbt.InvalidArgument: the argument '--rules' requires a value but none was supplied
```

I got even more confused when I saw that tests used that syntax: https://github.com/scalacenter/sbt-scalafix/blob/42a0eb006fc45f2d89b20bd219ad1948bf5a70d2/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala#L135

So this is an attempt at fixing that and a few other things (see commit messages). Error messages can probably be improved further, but that's how far I got with my current knowledge of the sbt parser lib!

My biggest disappointment is that for key/value extras currently unknown from sbt like `--tool-classpath`, there is currently no way to use space as key/value separator: the parser sends the key and the value as 2 separate arguments to `withParsedArguments` as it cannot tell/know if this is a flag or a key/value arg... Should we just list them all anyway? Is there a way to introspect the metaconfig from `scalafix-cli` to automate that and avoid drifting maybe?