### PR TITLE
Add support for rules defined/compiled within the same build

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixCoursier.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCoursier.scala
@@ -1,6 +1,5 @@
 package scalafix.internal.sbt
 
-import java.net.URLClassLoader
 import java.nio.file.Path
 import java.util.function
 import java.{util => jutil}
@@ -33,19 +32,16 @@ object ScalafixCoursier {
 
   def scalafixToolClasspath(
       deps: Seq[ModuleID],
-      customResolvers: Seq[cs.Repository],
-      parent: ClassLoader
-  ): URLClassLoader = {
+      customResolvers: Seq[cs.Repository]
+  ): Seq[URL] = {
     if (deps.isEmpty) {
-      new URLClassLoader(Array(), parent)
+      Nil
     } else {
       val jars = dependencyCache.computeIfAbsent(
         deps,
         fetchScalafixDependencies(customResolvers)
       )
-      val urls = jars.map(_.toUri.toURL).toArray
-      val classloader = new URLClassLoader(urls, parent)
-      classloader
+      jars.map(_.toUri.toURL)
     }
   }
 

--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -7,7 +7,52 @@ import sbt._
 import sbt.internal.sbtscalafix.Compat
 import scalafix.interfaces.{ScalafixArguments, Scalafix => ScalafixAPI}
 
-case class ScalafixInterface(api: ScalafixAPI, args: ScalafixArguments)
+class ScalafixInterface private (
+    val args: ScalafixArguments,
+    private val toolClasspath: URLClassLoader
+) {
+
+  // Accumulates the classpath via classloader delegation, as args.withToolClasspath() only considers the last call.
+  //
+  // We effectively end up with the following class loader hierarchy:
+  //   1. Meta-project sbt class loader
+  //       - bound to the sbt session
+  //   2. ScalafixInterfacesClassloader, loading `scalafix-interfaces` from its parent
+  //       - bound to the sbt session
+  //   3. `scalafix-cli` JARs
+  //       - bound to the sbt session
+  //   4. Global, external dependencies
+  //       - present only if custom dependencies were defined
+  //       - used for rule names autocompletion
+  //       - bound to the sbt session
+  //   5. Project-level, internal and external classpath for ScalafixConfig ivy configuration & dependencies for
+  //      CLI-requested `dependency:` rules
+  //       - present only on project-specific (local rules) or invocation-specific (`dependency:` rule) classpath
+  //       - recreated at each task invocation
+  def addToolClasspath(
+      extraExternalDeps: Seq[ModuleID],
+      customResolvers: Seq[Repository],
+      extraInternalDeps: Seq[File]
+  ): ScalafixInterface = {
+    if (extraExternalDeps.isEmpty && extraInternalDeps.isEmpty) {
+      this
+    } else {
+      val extraURLs = ScalafixCoursier
+        .scalafixToolClasspath(
+          extraExternalDeps,
+          customResolvers
+        ) ++ extraInternalDeps.map(_.toURI.toURL)
+
+      val newToolClasspath =
+        new URLClassLoader(extraURLs.toArray, toolClasspath)
+      new ScalafixInterface(
+        args.withToolClasspath(newToolClasspath),
+        newToolClasspath
+      )
+    }
+  }
+}
+
 object ScalafixInterface {
   private class LazyValue[T](thunk: () => T) extends (() => T) {
     private lazy val _value = scala.util.Try(thunk())
@@ -25,18 +70,16 @@ object ScalafixInterface {
         new ScalafixInterfacesClassloader(this.getClass.getClassLoader)
       val classloader = new URLClassLoader(urls, interfacesParent)
       val api = ScalafixAPI.classloadInstance(classloader)
-      val toolClasspath = ScalafixCoursier.scalafixToolClasspath(
-        scalafixDependencies,
-        scalafixCustomResolvers,
-        classloader
-      )
       val callback = new ScalafixLogger(logger)
 
       val args = api
         .newArguments()
-        .withToolClasspath(toolClasspath)
         .withMainCallback(callback)
 
-      ScalafixInterface(api, args)
+      new ScalafixInterface(args, classloader).addToolClasspath(
+        scalafixDependencies,
+        scalafixCustomResolvers,
+        Nil
+      )
     })
 }

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -151,7 +151,7 @@ object ScalafixPlugin extends AutoPlugin {
         terminalWidth = Some(JLineAccess.terminalWidth)
       ).parser.parsed
 
-      val projectDepsInternal =
+      val projectDepsInternal = products.in(ScalafixConfig).value ++
         internalDependencyClasspath.in(ScalafixConfig).value.map(_.data)
       val projectDepsExternal =
         externalDependencyClasspath

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -24,3 +24,9 @@ val service = project
     scalaVersion := Versions.scala213,
     libraryDependencies += "com.nequissimus" % "sort-imports_2.12" % "0.5.0" % ScalafixConfig
   )
+
+val sameproject = project
+  .settings(
+    scalaVersion := Versions.scala212, // the project scala version MUST match the one used by Scalafix
+    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % Versions.scalafixVersion % ScalafixConfig
+  )

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -1,0 +1,15 @@
+import _root_.scalafix.sbt.{BuildInfo => Versions}
+
+val rules = project
+  .disablePlugins(ScalafixPlugin)
+  .settings(
+    scalaVersion := Versions.scala212,
+    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % Versions.scalafixVersion,
+    libraryDependencies += "joda-time" % "joda-time" % "2.10.6"
+  )
+
+val service = project
+  .dependsOn(rules % ScalafixConfig)
+  .settings(
+    scalaVersion := Versions.scala212
+  )

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -21,5 +21,6 @@ val rules = project
 val service = project
   .dependsOn(rules % ScalafixConfig)
   .settings(
-    scalaVersion := Versions.scala213
+    scalaVersion := Versions.scala213,
+    libraryDependencies += "com.nequissimus" % "sort-imports_2.12" % "0.5.0" % ScalafixConfig
   )

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -13,6 +13,7 @@ val rules = project
   .disablePlugins(ScalafixPlugin)
   .settings(
     scalaVersion := Versions.scala212,
+    crossPaths := false,
     libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % Versions.scalafixVersion,
     libraryDependencies += "joda-time" % "joda-time" % "2.10.6"
   )
@@ -20,5 +21,5 @@ val rules = project
 val service = project
   .dependsOn(rules % ScalafixConfig)
   .settings(
-    scalaVersion := Versions.scala212
+    scalaVersion := Versions.scala213
   )

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -1,5 +1,14 @@
 import _root_.scalafix.sbt.{BuildInfo => Versions}
 
+inThisBuild(
+  List(
+    scalafixDependencies := List(
+      // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
+      "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
+    )
+  )
+)
+
 val rules = project
   .disablePlugins(ScalafixPlugin)
   .settings(

--- a/src/sbt-test/sbt-scalafix/local-rules/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/local-rules/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/src/sbt-test/sbt-scalafix/local-rules/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+local.Syntactic

--- a/src/sbt-test/sbt-scalafix/local-rules/rules/src/main/scala/local/NoOp.scala
+++ b/src/sbt-test/sbt-scalafix/local-rules/rules/src/main/scala/local/NoOp.scala
@@ -1,0 +1,10 @@
+package local
+
+import scalafix.v1._
+
+class Syntactic extends SyntacticRule("LocalSyntacticRule") {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    new org.joda.time.Instant() // let's pretent we need this for the rule logic
+    Patch.empty
+  }
+}

--- a/src/sbt-test/sbt-scalafix/local-rules/rules/src/test/scala/local/Boom.scala
+++ b/src/sbt-test/sbt-scalafix/local-rules/rules/src/test/scala/local/Boom.scala
@@ -1,0 +1,21 @@
+package local
+
+import scala.meta.Position
+
+import scalafix.lint.LintSeverity
+import scalafix.v1._
+
+// This is meant to be dropped-in in src/main to be usable
+class Syntactic extends SyntacticRule("LocalSyntacticRule") {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    Patch.lint(
+      Diagnostic(
+        "",
+        "expected lint error",
+        Position.None,
+        "",
+        LintSeverity.Error
+      )
+    )
+  }
+}

--- a/src/sbt-test/sbt-scalafix/local-rules/sameproject/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-scalafix/local-rules/sameproject/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+object Main

--- a/src/sbt-test/sbt-scalafix/local-rules/sameproject/src/scalafix/resources/META-INF/services/scalafix.v1.Rule
+++ b/src/sbt-test/sbt-scalafix/local-rules/sameproject/src/scalafix/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+sameproject.Syntactic

--- a/src/sbt-test/sbt-scalafix/local-rules/sameproject/src/scalafix/scala/sameproject/NoOp.scala
+++ b/src/sbt-test/sbt-scalafix/local-rules/sameproject/src/scalafix/scala/sameproject/NoOp.scala
@@ -1,0 +1,9 @@
+package sameproject
+
+import scalafix.v1._
+
+class Syntactic extends SyntacticRule("SameProjectSyntacticRule") {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    Patch.empty
+  }
+}

--- a/src/sbt-test/sbt-scalafix/local-rules/service/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-scalafix/local-rules/service/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+object Main

--- a/src/sbt-test/sbt-scalafix/local-rules/test
+++ b/src/sbt-test/sbt-scalafix/local-rules/test
@@ -11,3 +11,5 @@ $ delete rules/src/main/scala/local/NoOp.scala
 
 # run a rule included from a remote JAR referenced via the Scalafix ivy config
 > service/scalafix SortImports
+
+> sameproject/scalafix SameProjectSyntacticRule

--- a/src/sbt-test/sbt-scalafix/local-rules/test
+++ b/src/sbt-test/sbt-scalafix/local-rules/test
@@ -8,3 +8,6 @@ $ delete rules/src/main/scala/local/NoOp.scala
 
 # make sure scalafixDependencies is also honored by running a rule from a remote JAR
 > service/scalafix SyntacticRule
+
+# run a rule included from a remote JAR referenced via the Scalafix ivy config
+> service/scalafix SortImports

--- a/src/sbt-test/sbt-scalafix/local-rules/test
+++ b/src/sbt-test/sbt-scalafix/local-rules/test
@@ -1,0 +1,1 @@
+> service/scalafix LocalSyntacticRule

--- a/src/sbt-test/sbt-scalafix/local-rules/test
+++ b/src/sbt-test/sbt-scalafix/local-rules/test
@@ -1,4 +1,10 @@
 > service/scalafix LocalSyntacticRule
 
+# ensure updates to the rule definition (that we make sure compiles first) is reflected in the next run
+> rules/test:compile
+$ copy-file rules/src/test/scala/local/Boom.scala rules/src/main/scala/local/Boom.scala
+$ delete rules/src/main/scala/local/NoOp.scala
+-> service/scalafix LocalSyntacticRule
+
 # make sure scalafixDependencies is also honored by running a rule from a remote JAR
 > service/scalafix SyntacticRule

--- a/src/sbt-test/sbt-scalafix/local-rules/test
+++ b/src/sbt-test/sbt-scalafix/local-rules/test
@@ -1,1 +1,4 @@
 > service/scalafix LocalSyntacticRule
+
+# make sure scalafixDependencies is also honored by running a rule from a remote JAR
+> service/scalafix SyntacticRule

--- a/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
@@ -27,11 +27,13 @@ class ScalafixAPISuite extends AnyFunSuite {
     assume(!Properties.isWin)
     val baos = new ByteArrayOutputStream()
     val logger = Compat.ConsoleLogger(new PrintStream(baos))
-    val ScalafixInterface(_, args) = ScalafixInterface.fromToolClasspath(
-      List("com.geirsson" %% "example-scalafix-rule" % "1.3.0"),
-      ScalafixCoursier.defaultResolvers,
-      logger
-    )()
+    val args = ScalafixInterface
+      .fromToolClasspath(
+        List("com.geirsson" %% "example-scalafix-rule" % "1.3.0"),
+        ScalafixCoursier.defaultResolvers,
+        logger
+      )()
+      .args
     val tmp = Files.createTempFile("scalafix", "Tmp.scala")
     tmp.toFile.deleteOnExit()
     Files.write(


### PR DESCRIPTION
In our fairly big sbt build, we have decided to collocate custom rule definitions with the sources they run against, using a separate sbt project of the same root build, in order to make the process of adding/updating them as seamless as possible (since they are not meant to be distributed or used anywhere else). It's working, but requires a quite hacky use of `--tool-classpath` which can only be passed once, with a lot of coursier-based code from here inlined.

This is an attempt at bringing the feature upstream (that I refer to in the code as "local rules"), although I assume it's not a very common use-case.

I chose to implement it using an ivy configuration (which might have some side-effects I didn't think of!). That led me to 2 interesting thoughts:
1. That configuration can be used to reference external dependencies as well, as an alternative to `scalafixDependencies` (see 72cd47c). I assume this has a tiny extra cost for sbt builds not running coursier (<1.3 or with >=1.3 with coursier explicitly disabled), since these dependencies end up being fetched/stored twice on disk (once into the ivy cache, once into the coursier one) as far as I understand. But it makes it possible to bring some rules only for some modules (not necessarily `ThisBuild` like `scalafixDependencies`). I am not sure it's worth documenting/advertizing though...
1. At some point, I thought explicit usage of coursier could be removed by relying on sbt-librarymanagement only (helping https://github.com/scalacenter/scalafix/issues/1049 for example), but I realized we need to retrieve dynamic JARs for `dependency:*`, and I wouldn't know how to do that without coursier...