### PR TITLE
take into account config file BEFORE checking if rules are syntactic

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -143,12 +143,14 @@ object ScalafixPlugin extends AutoPlugin {
       if (shell0.rules.isEmpty && shell0.extra == List("--help")) {
         scalafixHelp
       } else {
+        val scalafixConf = scalafixConfig.value.map(_.toPath)
         val (shell, mainArgs0) = scalafixArgsFromShell(
           shell0,
           scalafixDependencies.in(ThisBuild).value,
           scalafixResolvers.in(ThisBuild).value
         )
         val mainArgs = mainArgs0
+          .withConfig(jutil.Optional.ofNullable(scalafixConf.orNull))
           .withRules(shell.rules.asJava)
           .safeWithArgs(shell.extra)
         val rulesThatWillRun = mainArgs.safeRulesThatWillRun()
@@ -175,8 +177,7 @@ object ScalafixPlugin extends AutoPlugin {
     runArgs(
       filesToFix(shellArgs, config).value,
       mainArgs,
-      streams.value.log,
-      scalafixConfig.value
+      streams.value.log
     )
   }
 
@@ -202,8 +203,7 @@ object ScalafixPlugin extends AutoPlugin {
         runArgs(
           files,
           args,
-          streams.value.log,
-          scalafixConfig.value
+          streams.value.log
         )
       }
     } else {
@@ -223,11 +223,9 @@ object ScalafixPlugin extends AutoPlugin {
   private def runArgs(
       paths: Seq[Path],
       mainArgs: ScalafixArguments,
-      logger: Logger,
-      config: Option[File]
+      logger: Logger
   ): Unit = {
     val finalArgs = mainArgs
-      .withConfig(jutil.Optional.ofNullable(config.map(_.toPath).orNull))
       .withPaths(paths.asJava)
 
     if (paths.nonEmpty) {

--- a/src/sbt-test/sbt-scalafix/custom-config/.scalafixxx.conf
+++ b/src/sbt-test/sbt-scalafix/custom-config/.scalafixxx.conf
@@ -1,0 +1,3 @@
+rules = [
+  RemoveUnused
+]

--- a/src/sbt-test/sbt-scalafix/custom-config/build.sbt
+++ b/src/sbt-test/sbt-scalafix/custom-config/build.sbt
@@ -1,0 +1,6 @@
+val V = _root_.scalafix.sbt.BuildInfo
+
+scalaVersion := V.scala212
+addCompilerPlugin(scalafixSemanticdb)
+scalacOptions ++= Seq("-Yrangepos", "-Ywarn-unused")
+scalafixConfig := Some(file(".scalafixxx.conf"))

--- a/src/sbt-test/sbt-scalafix/custom-config/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/custom-config/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/custom-config/src/main/scala/example/Example.scala
+++ b/src/sbt-test/sbt-scalafix/custom-config/src/main/scala/example/Example.scala
@@ -1,0 +1,8 @@
+package example
+
+import java.util.Map
+import scala.concurrent.Future
+
+object Example {
+  implicit val str = null.asInstanceOf[Map.Entry[Int, String]]
+}

--- a/src/sbt-test/sbt-scalafix/custom-config/test
+++ b/src/sbt-test/sbt-scalafix/custom-config/test
@@ -1,0 +1,1 @@
+> scalafix


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/1033

`RemoveUnused` was called without what's required for a semantic rule, as this default rule from the custom config was not picked up early enough, causing the choice to take the syntactic-only code path to be wrong.