### PR TITLE
deprecate auto-exported `Scalafix` tag

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -20,7 +20,7 @@ object ScalafixPlugin extends AutoPlugin {
   override def requires: Plugins = JvmPlugin
 
   object autoImport {
-    @deprecated("not used internally, use your own tag")
+    @deprecated("not used internally, use your own tag", "0.9.17")
     val Scalafix = Tags.Tag("scalafix")
 
     val scalafix: InputKey[Unit] =

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -20,6 +20,7 @@ object ScalafixPlugin extends AutoPlugin {
   override def requires: Plugins = JvmPlugin
 
   object autoImport {
+    @deprecated("not used internally, use your own tag")
     val Scalafix = Tags.Tag("scalafix")
 
     val scalafix: InputKey[Unit] =


### PR DESCRIPTION
Follow-up of https://github.com/scalacenter/sbt-scalafix/pull/100#discussion_r419377950