### PR TITLE
remove unused val & import

### DIFF
--- a/src/main/scala/scalafix/sbt/BuildInfo.scala
+++ b/src/main/scala/scalafix/sbt/BuildInfo.scala
@@ -2,11 +2,7 @@ package scalafix.sbt
 
 import java.util.Properties
 
-import sbt.internal.sbtscalafix.Compat
-
 object BuildInfo {
-  private[this] val Logger = Compat.ConsoleLogger(System.out)
-
   def scalafixVersion: String =
     property("scalafixVersion")
   @deprecated("Use scalafixVersion", "0.9.7")


### PR DESCRIPTION
https://github.com/scalacenter/sbt-scalafix/pull/116 triggered a warning, which turned into an error with https://github.com/scalacenter/sbt-scalafix/pull/114 that was merged right after without a rebase, causing `Release` and `CI` GitHub actions to fail on master.