### PR TITLE
deprecate usage of coursiersmall type in scalafixResolvers

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -4,7 +4,7 @@ import java.net.URLClassLoader
 import java.nio.file.Path
 import java.{util => jutil}
 
-import com.geirsson.coursiersmall.Repository
+import coursierapi.Repository
 import sbt._
 import sbt.internal.sbtscalafix.Compat
 import scalafix.interfaces.{Scalafix => ScalafixAPI, _}

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -3,7 +3,8 @@ package scalafix.sbt
 import java.io.PrintStream
 import java.nio.file.{Path, Paths}
 
-import com.geirsson.coursiersmall.Repository
+import com.geirsson.{coursiersmall => cs}
+import coursierapi.Repository
 import sbt.KeyRanks.Invisible
 import sbt.Keys._
 import sbt._
@@ -37,6 +38,20 @@ object ScalafixPlugin extends AutoPlugin {
       settingKey[Boolean](
         "Cache scalafix invocations (off by default, still experimental)."
       )
+
+    import scala.language.implicitConversions
+    @deprecated(
+      "Usage of coursiersmall.Repository is deprecated, use coursierapi.Repository instead",
+      "0.9.17"
+    )
+    implicit def coursiersmall2coursierapi(
+        csRepository: cs.Repository
+    ): Repository =
+      csRepository match {
+        case m: cs.Repository.Maven => coursierapi.MavenRepository.of(m.root)
+        case i: cs.Repository.Ivy => coursierapi.IvyRepository.of(i.root)
+        case cs.Repository.Ivy2Local => coursierapi.Repository.ivy2Local()
+      }
     val scalafixResolvers: SettingKey[Seq[Repository]] =
       settingKey[Seq[Repository]](
         "Optional list of Maven/Ivy repositories to use for fetching custom rules."

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -1,3 +1,5 @@
+import com.geirsson.coursiersmall.Repository // deprecated, but checks source compatibility
+
 inThisBuild(
   List(
     scalaVersion := "2.12.11",
@@ -9,7 +11,8 @@ inThisBuild(
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
       "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
-    )
+    ),
+    scalafixResolvers := List(Repository.MavenCentral)
   )
 )
 

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -5,6 +5,11 @@ inThisBuild(
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/olafurpg/example-scalafix-rule
       "com.geirsson" %% "example-scalafix-rule" % "1.3.0"
+    ),
+    // `Repository.central()` can only be used sbt 1.x / scala 2.12
+    // error: Static methods in interface require -target:jvm-1.8
+    scalafixResolvers := List(
+      coursierapi.MavenRepository.of("https://repo1.maven.org/maven2")
     )
   )
 )


### PR DESCRIPTION
This is breaking binary compatibility, but preserves source compatibility via (deprecated) implicit conversion, which is always in scope for `*.sbt` sources, but require an explicit import for `*.scala`
sources, such as `import scalafix.sbt.ScalafixPlugin.autoImport._`.

That means that most 99% of direct sbt-scalafix users should be fine, but any plugin published against sbt-scalafix will need to be rebuilt.

Usage of coursierapi is a bit more cumbersome for sbt 0.13.x because the Java8 static methods in Repository cannot be used from Scala 2.10... As the scripted shows, it's still possible to setup resolvers without these helpers.