### PR TITLE
support sbt 1.3.x SemanticdbPlugin in ScalafixTestkitPlugin (take 2)

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
@@ -33,11 +33,16 @@ object ScalafixTestkitPlugin extends AutoPlugin {
       scalafixTestkitInputScalaVersion := scalaVersion.value,
       resourceGenerators.in(Test) += Def.task {
         val props = new java.util.Properties()
+        val targetrootClasspath = semanticdbOption(
+          scalafixTestkitInputScalacOptions.value,
+          "targetroot"
+        ).map(file).toSeq
         val values = Map[String, Seq[File]](
           "sourceroot" ->
             List(baseDirectory.in(ThisBuild).value),
           "inputClasspath" ->
-            scalafixTestkitInputClasspath.value.map(_.data),
+            (scalafixTestkitInputClasspath.value
+              .map(_.data) ++ targetrootClasspath),
           "inputSourceDirectories" ->
             scalafixTestkitInputSourceDirectories.value,
           "outputSourceDirectories" ->
@@ -62,4 +67,15 @@ object ScalafixTestkitPlugin extends AutoPlugin {
         List(out)
       }
     )
+
+  private def semanticdbOption(
+      scalacOptions: Seq[String],
+      name: String
+  ): Option[String] = {
+    val flag = s"-P:semanticdb:$name:"
+    scalacOptions
+      .filter(_.startsWith(flag))
+      .lastOption
+      .map(_.stripPrefix(flag))
+  }
 }

--- a/src/sbt-test/sbt-1.3/testkit/rules/src/main/scala/fix/Semantic.scala
+++ b/src/sbt-test/sbt-1.3/testkit/rules/src/main/scala/fix/Semantic.scala
@@ -4,6 +4,7 @@ import scalafix.v1._
 
 class Semantic extends SemanticRule("SemanticRule") {
   override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.diagnostics // force lookup of semanticdb-provided info
     if (doc.input.text.contains(s"// v1 $name!")) Patch.empty
     else Patch.addRight(doc.tree, s"// v1 $name!\n")
   }


### PR DESCRIPTION
The test for 4278a1f was too weak as it was not triggering the (lazy) lookup of semanticdb files.

This replicates [the behavior of `scalafix-cli`](https://github.com/scalacenter/scalafix/blob/v0.9.17/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala#L316-L341), inspecting `scalacOptions` to detect a potential custom classpath for semanticdb files (set by default as `semanticdbIncludeInJar := false`).

https://github.com/sbt/sbt/blob/v1.3.12/main/src/main/scala/sbt/Defaults.scala#L469