### PR TITLE
Introduce scalafixAll InputTask

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -9,7 +9,7 @@ import sbt.complete._
 import sbt.complete.DefaultParsers._
 
 class ScalafixCompletions(
-    workingDirectory: () => Path,
+    workingDirectory: Path,
     loadedRules: () => Seq[ScalafixRule],
     terminalWidth: Option[Int]
 ) {
@@ -66,9 +66,9 @@ class ScalafixCompletions(
     }
 
     string
-      .examples(new AbsolutePathExamples(workingDirectory()))
+      .examples(new AbsolutePathExamples(workingDirectory))
       .map { f =>
-        toAbsolutePath(Paths.get(f), workingDirectory())
+        toAbsolutePath(Paths.get(f), workingDirectory)
       }
       .filter(f => Files.exists(f), x => x)
   }
@@ -96,7 +96,7 @@ class ScalafixCompletions(
   private val namedRule2: Parser[ShellArgs.Rule] =
     namedRule.map(s => ShellArgs.Rule(s))
   private lazy val gitDiffParser: P = {
-    val jgitCompletion = new JGitCompletion(workingDirectory())
+    val jgitCompletion = new JGitCompletion(workingDirectory)
     token(
       NotQuoted,
       TokenCompletions.fixed((seen, _) => {

--- a/src/sbt-test/sbt-scalafix/cross-build/test
+++ b/src/sbt-test/sbt-scalafix/cross-build/test
@@ -1,6 +1,7 @@
 # compile should not affect scalafix
 > compile
 
+-> scalafixAll --test ProcedureSyntax
 -> scalafix --test ProcedureSyntax
 -> compile:scalafix --test ProcedureSyntax
 -> test:scalafix --test ProcedureSyntax
@@ -17,7 +18,7 @@
 > test:scalafix --test ProcedureSyntax
 -> it:scalafix --test ProcedureSyntax
 
-> it:scalafix ProcedureSyntax
+> scalafixAll ProcedureSyntax
 > it:scalafix --test ProcedureSyntax
 
 > javaProject/compile:scalafix ProcedureSyntax

--- a/src/sbt-test/sbt-scalafix/inconfig/test
+++ b/src/sbt-test/sbt-scalafix/inconfig/test
@@ -1,5 +1,9 @@
 -> ; example/scalafix --test ; example/it:scalafix --test
+-> example/scalafixAll --test
 > example/it:scalafix
 > example/it:scalafix --test
 -> example/scalafix --test
 > tests/test
+> example/scalafixAll
+> example/scalafixAll --test
+> example/scalafix --test

--- a/src/sbt-test/skip-windows/caching/test
+++ b/src/sbt-test/skip-windows/caching/test
@@ -205,6 +205,24 @@ $ exec chmod 000 src/test/scala/Valid.scala
 $ delete src/main/scala
 $ delete src/test/scala
 
+# scalafixAll and scalafix should share the same cache per configuration
+> set scalafixConfig := None
+$ mkdir src/main/scala
+$ mkdir src/test/scala
+$ copy-file files/UnusedImports.scala src/main/scala/Valid.scala
+$ copy-file files/ProcedureSyntax.scala src/test/scala/InitiallyInvalid.scala
+-> scalafixAll --check ProcedureSyntax
+$ exec chmod 000 src/main/scala/Valid.scala
+> scalafix --check ProcedureSyntax
+-> test:scalafix --check ProcedureSyntax
+> test:scalafix ProcedureSyntax
+$ exec chmod 000 src/test/scala/InitiallyInvalid.scala
+> scalafix --check ProcedureSyntax
+> test:scalafix --check ProcedureSyntax
+> scalafixAll --check ProcedureSyntax
+$ delete src/main/scala
+$ delete src/test/scala
+
 # make sure the cache is disabled when using `--stdout`
 > set scalafixConfig := None
 $ mkdir src/main/scala

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -35,7 +35,7 @@ class SbtCompletionsSuite extends AnyFunSuite {
   val loadedRules = mainArgs.availableRules.toList
 
   val parser = new ScalafixCompletions(
-    workingDirectory = () => fs.workingDirectory.toAbsolutePath,
+    workingDirectory = fs.workingDirectory.toAbsolutePath,
     loadedRules = () => loadedRules,
     terminalWidth = None
   ).parser


### PR DESCRIPTION
Docs companion: https://github.com/scalacenter/scalafix/pull/1160

Similarly to [`scalafmtAll`](https://github.com/scalameta/sbt-scalafmt/blob/v2.4.0/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala#L436) (except that the implementation here is more tricky as we deal with an `InputTask` for which [`.all`](https://www.scala-sbt.org/1.x/docs/Tasks.html#Getting+values+from+multiple+scopes) does not work), this allows a user to easily and efficiently run Scalafix across configurations for a given project (or of course for all projects/configurations with root project aggregation)

I saw there [were previous discussions/opinions about that](https://github.com/scalacenter/scalafix/pull/587#issuecomment-365218154) (I should have opened an issue to discuss that beforehand). From my side I see no reason not to do it, especially because implementation is hard(er) downstream but simple here (or at least readable & compact), and because it allows `scalafix --check` to run in parallel over all configurations (rather than in sequential as documented in https://scalacenter.github.io/scalafix/docs/users/installation.html#enforce-in-ci), so it's not just sugar.

There has already been work downstream to bring that to users through a command (like https://github.com/alejandrohdezma/sbt-fix#running-scalafix-in-all-configurations), but refactoring the code here allows us to expose an `InputTask`, with the same auto-completion as the existing `scalafix`, which can't be done downstream at the moment.

The first commit is preliminary, separating parsing & core logic from `scalafix` so that the output of the parser is reused across configurations during a `scalafixAll` invocation, and getting rid of a workaround.
