### PR TITLE
test/document usage of local 2.13 rules

### DIFF
--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -10,15 +10,17 @@ inThisBuild(
     // error: Static methods in interface require -target:jvm-1.8
     scalafixResolvers := List(
       coursierapi.MavenRepository.of("https://repo1.maven.org/maven2")
-    )
+    ),
+    scalaVersion := "2.13.0", // out of sync with scalafix.sbt.BuildInfo.scala213 on purpose
+    scalafixScalaBinaryVersion :=
+      // this should be the default in sbt-scalafix 1.0
+      CrossVersion.binaryScalaVersion(scalaVersion.value)
   )
 )
 
 val rules = project
   .disablePlugins(ScalafixPlugin)
   .settings(
-    scalaVersion := Versions.scala212,
-    crossPaths := false,
     libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % Versions.scalafixVersion,
     libraryDependencies += "joda-time" % "joda-time" % "2.10.6"
   )
@@ -26,12 +28,10 @@ val rules = project
 val service = project
   .dependsOn(rules % ScalafixConfig)
   .settings(
-    scalaVersion := Versions.scala213,
-    libraryDependencies += "com.nequissimus" % "sort-imports_2.12" % "0.5.0" % ScalafixConfig
+    libraryDependencies += "com.nequissimus" %% "sort-imports" % "0.5.2" % ScalafixConfig
   )
 
 val sameproject = project
   .settings(
-    scalaVersion := Versions.scala212, // the project scala version MUST match the one used by Scalafix
     libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % Versions.scalafixVersion % ScalafixConfig
   )


### PR DESCRIPTION
Somehow, [this got lost](https://github.com/scalacenter/sbt-scalafix/compare/5316d91..fd97d1a#diff-989d991e5bc1817b8d9f0b2eef7af260) when I [addressed @olafurpg's comments](https://github.com/scalacenter/sbt-scalafix/pull/121#issuecomment-643939807). It demonstrates the second goal of https://github.com/scalacenter/sbt-scalafix/pull/121

> 2. Advanced users with local rules targeting 2.11 or 2.13 code will be able to simplify their build