### PR TITLE
Fix git-based versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7
       - uses: olafurpg/setup-gpg@v2
-      - run: git fetch --unshallow
+      - run: git fetch --prune --unshallow --tags
       - name: Publish ${{ github.ref }}
         run: sbt ci-release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  pull_request:
   push:
     branches: [master]
     tags: ["*"]


### PR DESCRIPTION
Since https://github.com/scalacenter/sbt-scalafix/actions/runs/133589468, `git unshallow` does not seem to do anything, resulting in `sbt-dynver` using a `0.0.0+xxx` version, and `sbt-ci-release` [publishing it](https://oss.sonatype.org/content/repositories/snapshots/ch/epfl/scala/sbt-scalafix_2.12_1.0/).

[With bd02752](https://pipelines.actions.githubusercontent.com/1EtuykwW0rDiVQCkmkFqSQkGZCujB44PBdhNUnI6E4H1wazXw6/_apis/pipelines/1/runs/224/signedlogcontent/3?urlExpires=2020-06-16T19%3A56%3A18.0197508Z&urlSigningMethod=HMACV1&urlSignature=U2GZIu4V8deYbRRzRCnG9x1RVEMp4b8%2B1MbtKqcW%2BQ0%3D)
```
2020-06-16T19:53:34.8809822Z [info] Welcome to sbt-scalafix 0.9.17+19-c91c09b4-SNAPSHOT
```

[Without](https://github.com/scalacenter/sbt-scalafix/pull/130/checks?check_run_id=777950696):
```
2020-06-16T19:57:55.5115311Z [info] Welcome to sbt-scalafix 0.9.17+18-e0f9a656-SNAPSHOT
```

-> this is not helping... https://gitter.im/scalacenter/scalafix?at=5ee93a68ef5c1c28f0290a89