### PR TITLE
Upgrade to Scalatest 3.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ resolvers += Resolver.sonatypeRepo("public")
 libraryDependencies ++= Dependencies.all
 libraryDependencies ++= List(
   "com.lihaoyi" %% "fansi" % "0.2.6" % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test
+  "org.scalatest" %% "scalatest" % "3.2.0" % Test
 )
 
 // Cross-building settings (see https://github.com/sbt/sbt/issues/3473#issuecomment-325729747)

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -4,7 +4,8 @@ inThisBuild(
   List(
     scalaVersion := "2.12.11",
     libraryDependencies ++= List(
-      "org.scalameta" %% "testkit" % "4.0.0-M6" % Test,
+      "org.scalameta" %% "testkit" % "4.3.10" % Test,
+      "org.scalameta" %% "munit" % "0.7.9" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
       "org.scalatest" %% "scalatest" % "3.2.0" % Test
     ),

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -6,7 +6,7 @@ inThisBuild(
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % "4.0.0-M6" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
-      "org.scalatest" %% "scalatest" % "3.1.2" % Test
+      "org.scalatest" %% "scalatest" % "3.2.0" % Test
     ),
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/scalacenter/example-scalafix-rule

--- a/src/sbt-test/sbt-scalafix/basic/tests/src/test/scala/tests/CheckSuite.scala
+++ b/src/sbt-test/sbt-scalafix/basic/tests/src/test/scala/tests/CheckSuite.scala
@@ -1,10 +1,10 @@
 package tests
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.internal.io._
 import scala.meta.testkit._
 
-class CheckSuite extends FunSuite with DiffAssertions {
+class CheckSuite extends AnyFunSuite with DiffAssertions {
 
   test("> scalafix") {
     val root = PathIO.workingDirectory.resolve("example").resolve("src")

--- a/src/sbt-test/sbt-scalafix/basic/tests/src/test/scala/tests/CheckSuite.scala
+++ b/src/sbt-test/sbt-scalafix/basic/tests/src/test/scala/tests/CheckSuite.scala
@@ -2,9 +2,9 @@ package tests
 
 import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.internal.io._
-import scala.meta.testkit._
+import scala.meta.testkit.StringFS
 
-class CheckSuite extends AnyFunSuite with DiffAssertions {
+class CheckSuite extends AnyFunSuite {
 
   test("> scalafix") {
     val root = PathIO.workingDirectory.resolve("example").resolve("src")
@@ -21,7 +21,7 @@ class CheckSuite extends AnyFunSuite with DiffAssertions {
         |}
         |// Hello world!
         |""".stripMargin
-    assertNoDiff(obtained, expected)
+    munit.Assertions.assertNoDiff(obtained, expected)
   }
 
 }

--- a/src/sbt-test/sbt-scalafix/inconfig/build.sbt
+++ b/src/sbt-test/sbt-scalafix/inconfig/build.sbt
@@ -2,7 +2,8 @@ inThisBuild(
   List(
     scalaVersion := "2.12.11",
     libraryDependencies ++= List(
-      "org.scalameta" %% "testkit" % "4.0.0-M6" % Test,
+      "org.scalameta" %% "testkit" % "4.3.10" % Test,
+      "org.scalameta" %% "munit" % "0.7.9" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
       "org.scalatest" %% "scalatest" % "3.2.0" % Test
     ),

--- a/src/sbt-test/sbt-scalafix/inconfig/build.sbt
+++ b/src/sbt-test/sbt-scalafix/inconfig/build.sbt
@@ -4,7 +4,7 @@ inThisBuild(
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % "4.0.0-M6" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
-      "org.scalatest" %% "scalatest" % "3.1.2" % Test
+      "org.scalatest" %% "scalatest" % "3.2.0" % Test
     ),
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/scalacenter/example-scalafix-rule

--- a/src/sbt-test/sbt-scalafix/inconfig/tests/src/test/scala/tests/CheckSuite.scala
+++ b/src/sbt-test/sbt-scalafix/inconfig/tests/src/test/scala/tests/CheckSuite.scala
@@ -1,10 +1,10 @@
 package tests
 
-import org.scalatest._
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.internal.io._
 import scala.meta.testkit._
 
-class CheckSuite extends FunSuite with DiffAssertions {
+class CheckSuite extends AnyFunSuite with DiffAssertions {
 
   test("> scalafix") {
     val root = PathIO.workingDirectory.resolve("example").resolve("src")

--- a/src/sbt-test/sbt-scalafix/inconfig/tests/src/test/scala/tests/CheckSuite.scala
+++ b/src/sbt-test/sbt-scalafix/inconfig/tests/src/test/scala/tests/CheckSuite.scala
@@ -2,9 +2,9 @@ package tests
 
 import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.internal.io._
-import scala.meta.testkit._
+import scala.meta.testkit.StringFS
 
-class CheckSuite extends AnyFunSuite with DiffAssertions {
+class CheckSuite extends AnyFunSuite {
 
   test("> scalafix") {
     val root = PathIO.workingDirectory.resolve("example").resolve("src")
@@ -26,7 +26,7 @@ class CheckSuite extends AnyFunSuite with DiffAssertions {
         |  implicit val str = null.asInstanceOf[java.util.Map.Entry[Int, String]]
         |}
         |""".stripMargin
-    assertNoDiff(obtained, expected)
+    munit.Assertions.assertNoDiff(obtained, expected)
   }
 
 }


### PR DESCRIPTION
Supersedes #131 

Fixes the compile errors caused by using the deprecated `scala.meta.testkit.DiffAssertions`