### PR TITLE
prevent failure on sbt init when JGit finds a .git with no commit

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/JGitCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/JGitCompletions.scala
@@ -11,6 +11,7 @@ import org.eclipse.jgit.util.GitDateFormatter
 
 import java.nio.file.Path
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 class JGitCompletion(cwd: Path) {
   private val isGitRepository =
@@ -24,7 +25,8 @@ class JGitCompletion(cwd: Path) {
       val refList0 =
         repo.getRefDatabase().getRefsByPrefix(RefDatabase.ALL).asScala
       val git = new Git(repo)
-      val refs0 = git.log().setMaxCount(20).call().asScala.toList
+      val refs0 =
+        Try(git.log().setMaxCount(20).call().asScala.toList).getOrElse(Nil)
       (refList0, refs0)
     } else {
       (Nil, Nil)

--- a/src/test/scala/scalafix/internal/sbt/JGitCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/JGitCompletionsSuite.scala
@@ -1,0 +1,28 @@
+package scalafix.internal.sbt
+
+import org.eclipse.jgit.api.{Git => JGit}
+import org.scalatest.funsuite.AnyFunSuite
+
+class JGitCompletionsSuite extends AnyFunSuite {
+
+  test("directory with no .git") {
+    val fs = new Fs()
+    val jgit = new JGitCompletion(fs.workingDirectory)
+    assert(jgit.last20Commits == Nil)
+  }
+
+  test("directory with empty .git") {
+    val fs = new Fs()
+    fs.mkdir(".git")
+    val jgit = new JGitCompletion(fs.workingDirectory)
+    assert(jgit.last20Commits == Nil)
+  }
+
+  test("directory with no commits") {
+    val fs = new Fs()
+    JGit.init().setDirectory(fs.workingDirectory.toFile).call() // git init
+    val jgit = new JGitCompletion(fs.workingDirectory)
+    assert(jgit.last20Commits == Nil)
+  }
+
+}


### PR DESCRIPTION
Ref https://github.com/scalacenter/scalafix/issues/1196
Regression detected between 0.9.17 & 0.9.18, introduced by https://github.com/scalacenter/sbt-scalafix/pull/126

2ca68e4 exposed the failure to lookup commits during sbt initialization, while it would only happen on `scalafix` invocation earlier.

While looking at that, I initially thought 2ca68e4 changed the behavior by eagerly fetching the last commits into a setting, but [that lookup is memoized in a lazy val anyway](https://github.com/scalacenter/sbt-scalafix/blob/v0.9.17/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala#L98-L99), so a `sbt reload` is required before or after 2ca68e4 to get an up-to-date list of commits.