### PR TITLE
Fix 0.9.18 caching/performance regressions

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
+++ b/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
@@ -1,0 +1,21 @@
+package scalafix.internal.sbt
+
+import scala.collection.mutable
+
+/** A basic thread-safe cache without any eviction. */
+class BlockingCache[K, V] {
+  private val underlying = new mutable.HashMap[K, V]
+
+  /**
+    * @param value By-name parameter evaluated when the key if missing. Value computation is guaranteed
+    *              to be called only once per key across all invocations.
+    */
+  def getOrElseUpdate(key: K, value: => V): V = {
+    // ConcurrentHashMap does not guarantee that there is only one evaluation of the value, so
+    // we use our own (global) locking, which is OK as the number of keys is expected to be
+    // very small (bound by the number of projects in the sbt build).
+    underlying.synchronized {
+      underlying.getOrElseUpdate(key, value)
+    }
+  }
+}

--- a/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
+++ b/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
@@ -1,21 +1,22 @@
 package scalafix.internal.sbt
 
-import scala.collection.mutable
+import java.{util => ju}
 
 /** A basic thread-safe cache without any eviction. */
 class BlockingCache[K, V] {
-  private val underlying = new mutable.HashMap[K, V]
+
+  // Number of keys is expected to be very small so the global lock should not be a bottleneck
+  private val underlying = ju.Collections.synchronizedMap(new ju.HashMap[K, V])
 
   /**
     * @param value By-name parameter evaluated when the key if missing. Value computation is guaranteed
     *              to be called only once per key across all invocations.
     */
-  def getOrElseUpdate(key: K, value: => V): V = {
-    // ConcurrentHashMap does not guarantee that there is only one evaluation of the value, so
-    // we use our own (global) locking, which is OK as the number of keys is expected to be
-    // very small (bound by the number of projects in the sbt build).
-    underlying.synchronized {
-      underlying.getOrElseUpdate(key, value)
-    }
-  }
+  def getOrElseUpdate(key: K, value: => V): V =
+    underlying.computeIfAbsent(
+      key,
+      new ju.function.Function[K, V] {
+        override def apply(k: K): V = value
+      }
+    )
 }

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -123,6 +123,20 @@ object ScalafixPlugin extends AutoPlugin {
       Invisible
     )
 
+  private val scalafixInterfaceProvider: SettingKey[() => ScalafixInterface] =
+    SettingKey(
+      "scalafixInterfaceProvider",
+      "Implementation detail - do not use",
+      Invisible
+    )
+
+  private val scalafixParser: SettingKey[Parser[ShellArgs]] =
+    SettingKey(
+      "scalafixParser",
+      "Implementation detail - do not use",
+      Invisible
+    )
+
   override lazy val projectConfigurations: Seq[Configuration] =
     Seq(ScalafixConfig)
 
@@ -147,7 +161,19 @@ object ScalafixPlugin extends AutoPlugin {
       )
     ),
     scalafixDependencies := Nil,
-    commands += ScalafixEnable.command
+    commands += ScalafixEnable.command,
+    scalafixInterfaceProvider := ScalafixInterface.fromToolClasspath(
+      scalafixScalaBinaryVersion.in(ThisBuild).value,
+      scalafixDependencies = scalafixDependencies.in(ThisBuild).value,
+      scalafixCustomResolvers = scalafixResolvers.in(ThisBuild).value
+    ),
+    scalafixParser := new ScalafixCompletions(
+      workingDirectory = baseDirectory.in(ThisBuild).value.toPath,
+      // Unfortunately, local rules will not show up as completions in the parser, as that parser can only
+      // depend on settings, while local rules classpath must be looked up via tasks
+      loadedRules = () => scalafixInterfaceProvider.value().availableRules(),
+      terminalWidth = Some(JLineAccess.terminalWidth)
+    ).parser
   )
 
   override def buildSettings: Seq[Def.Setting[_]] =
@@ -156,25 +182,6 @@ object ScalafixPlugin extends AutoPlugin {
     )
 
   lazy val stdoutLogger = Compat.ConsoleLogger(System.out)
-
-  private val scalafixInterface: Def.Initialize[() => ScalafixInterface] =
-    Def.setting {
-      ScalafixInterface.fromToolClasspath(
-        scalafixScalaBinaryVersion.in(ThisBuild).value,
-        scalafixDependencies = scalafixDependencies.in(ThisBuild).value,
-        scalafixCustomResolvers = scalafixResolvers.in(ThisBuild).value
-      )
-    }
-
-  private val parser: Def.Initialize[Parser[ShellArgs]] = Def.setting {
-    new ScalafixCompletions(
-      workingDirectory = baseDirectory.in(ThisBuild).value.toPath,
-      // Unfortunately, local rules will not show up as completions in the parser, as that parser can only
-      // depend on settings, while local rules classpath must be looked up via tasks
-      loadedRules = () => scalafixInterface.value().availableRules(),
-      terminalWidth = Some(JLineAccess.terminalWidth)
-    ).parser
-  }
 
   private def scalafixArgsFromShell(
       shell: ShellArgs,
@@ -222,7 +229,7 @@ object ScalafixPlugin extends AutoPlugin {
   private def scalafixAllInputTask(): Def.Initialize[InputTask[Unit]] =
     // workaround https://github.com/sbt/sbt/issues/3572 by invoking directly what Def.inputTaskDyn would via macro
     InputTask
-      .createDyn(InputTask.initParserAsInput(parser))(
+      .createDyn(InputTask.initParserAsInput(scalafixParser))(
         Def.task(shellArgs => scalafixAllTask(shellArgs, thisProject.value))
       )
 
@@ -246,7 +253,7 @@ object ScalafixPlugin extends AutoPlugin {
   ): Def.Initialize[InputTask[Unit]] =
     // workaround https://github.com/sbt/sbt/issues/3572 by invoking directly what Def.inputTaskDyn would via macro
     InputTask
-      .createDyn(InputTask.initParserAsInput(parser))(
+      .createDyn(InputTask.initParserAsInput(scalafixParser))(
         Def.task(shellArgs => scalafixTask(shellArgs, config))
       )
 
@@ -276,7 +283,7 @@ object ScalafixPlugin extends AutoPlugin {
         val scalafixConf = scalafixConfig.in(config).value.map(_.toPath)
         val (shell, mainInterface0) = scalafixArgsFromShell(
           shellArgs,
-          scalafixInterface.value,
+          scalafixInterfaceProvider.value,
           projectDepsExternal,
           scalafixDependencies.in(ThisBuild).value,
           scalafixResolvers.in(ThisBuild).value,
@@ -306,7 +313,10 @@ object ScalafixPlugin extends AutoPlugin {
     }
   private def scalafixHelp: Def.Initialize[Task[Unit]] =
     Def.task {
-      scalafixInterface.value().withArgs(Arg.ParsedArgs(List("--help"))).run()
+      scalafixInterfaceProvider
+        .value()
+        .withArgs(Arg.ParsedArgs(List("--help")))
+        .run()
       ()
     }
 


### PR DESCRIPTION
* The first commit fixes an embarrassingly massive performance regression introduced by 2ca68e4: the comment/assumption in https://github.com/scalacenter/sbt-scalafix/pull/126#discussion_r439692348 was wrong, causing artifact resolution & classloader creation to happen for each invocation/project/configuration, which caused slow startup and slower rule execution (JIT not warmed up). It might also fix https://github.com/scalacenter/scalafix/issues/1196#issuecomment-654744979.
* The second commit brings back the 0.9.17 behavior of looking up last commits for the parser at the first `scalafix` invocation (changed also in 2ca68e4), to reduce the risk of JGit stuff blocking the initialization like https://github.com/scalacenter/scalafix/issues/1196. Related to https://github.com/scalacenter/sbt-scalafix/pull/141.
* The two last commits fix a minor known regression introduced by https://github.com/scalacenter/sbt-scalafix/commit/d81dd7266231e70af475551b563b21ec75c89482 (see message of that commit).

We'll probably need some performance tests to catch those regressions in the future...

### Testing on a real project

I have timed the initialization overhead of `scalafix` by running a warm `all scalafix test:scalafix it:scalafix` (third invocation with `scalafixCaching := true`) on a build with 25 sub-projects which have Scalafix enabled.

* With `scalafixDependencies`
  * 0.9.16: ~10s
  * 0.9.18: ~50s
  * This PR: ~8s

* With `scalafixDependencies` & `dependsOn(customRules % ScalafixConfig)`
  * 0.9.16: ~10s
  * 0.9.18: ~50s
  * This PR: ~9s

The impact of (not) JITing the rules is not exposed by this test, but rule execution should be back to pre-0.9.18 level as well.