### PR TITLE
add scalafixOnCompileConfig to separate .scalafix.conf for scalafix-on-compilation

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ShellArgs.scala
+++ b/src/main/scala/scalafix/internal/sbt/ShellArgs.scala
@@ -28,4 +28,12 @@ case class ShellArgs(
     files: List[String] = Nil,
     extra: List[String] = Nil,
     noCache: Boolean = false
-)
+) {
+  def +(that: ShellArgs): ShellArgs =
+    ShellArgs(
+      this.rules ::: that.rules,
+      this.files ::: that.files,
+      this.extra ::: that.extra,
+      this.noCache || that.noCache
+    )
+}

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -89,7 +89,7 @@ object ScalafixPlugin extends AutoPlugin {
         "Optional location to .scalafix.conf file to specify which scalafix rules should run. " +
           "Defaults to the build base directory if a .scalafix.conf file exists."
       )
-    val scalafixConfigOnCompile: SettingKey[Option[File]] =
+    val scalafixOnCompileConfig: SettingKey[Option[File]] =
       settingKey[Option[File]](
         "Optional location to .scalafix.conf file to specify which scalafix rules should run on compile. " +
           "Defaults to the same as scalafixConfig."

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -91,8 +91,8 @@ object ScalafixPlugin extends AutoPlugin {
       )
     val scalafixOnCompileConfig: SettingKey[File] =
       settingKey[File](
-        "Optional location to .scalafix.conf file to specify which scalafix rules should run on compile. " +
-          "Defaults to the same as scalafixConfig."
+        "Location to .scalafix.conf file to specify which scalafix rules should run on compile. " +
+          "scalafixOnCompile must be set for this to have an effect. Defaults to the same as scalafixConfig."
       )
     val scalafixSemanticdb: ModuleID =
       scalafixSemanticdb(BuildInfo.scalametaVersion)

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -89,8 +89,8 @@ object ScalafixPlugin extends AutoPlugin {
         "Optional location to .scalafix.conf file to specify which scalafix rules should run. " +
           "Defaults to the build base directory if a .scalafix.conf file exists."
       )
-    val scalafixOnCompileConfig: SettingKey[Option[File]] =
-      settingKey[Option[File]](
+    val scalafixOnCompileConfig: SettingKey[File] =
+      settingKey[File](
         "Optional location to .scalafix.conf file to specify which scalafix rules should run on compile. " +
           "Defaults to the same as scalafixConfig."
       )
@@ -185,7 +185,6 @@ object ScalafixPlugin extends AutoPlugin {
 
   override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
     scalafixConfig := None, // let scalafix-cli try to infer $CWD/.scalafix.conf
-    scalafixConfigOnCompile := scalafixConfig.value,
     scalafixOnCompile := false,
     scalafixResolvers := Seq(
       Repository.ivy2Local(),
@@ -352,7 +351,12 @@ object ScalafixPlugin extends AutoPlugin {
       } else {
         val scalafixConf =
           if (scalafixRunExplicitly.value) scalafixConfig.in(config).value
-          else scalafixConfigOnCompile.in(config).value
+          else
+            scalafixOnCompileConfig
+              .in(config)
+              .?
+              .value
+              .orElse(scalafixConfig.in(config).value)
         val (shell, mainInterface0) = scalafixArgsFromShell(
           shellArgs,
           scalafixInterfaceProvider.value,

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -387,7 +387,7 @@ object ScalafixPlugin extends AutoPlugin {
       if (shellArgs.rules.isEmpty && shellArgs.extra == List("--help")) {
         scalafixHelp
       } else {
-        val scalafixConf = scalafixConfig.in(config).value
+        val scalafixConf = scalafixConfig.in(config).value.map(_.toPath)
         val (shell, mainInterface0) = scalafixArgsFromShell(
           shellArgs,
           scalafixInterfaceProvider.value,
@@ -404,7 +404,7 @@ object ScalafixPlugin extends AutoPlugin {
           .withArgs(maybeNoCache: _*)
           .withArgs(
             Arg.PrintStream(errorLogger),
-            Arg.Config(scalafixConf.map(_.toPath)),
+            Arg.Config(scalafixConf),
             Arg.Rules(shell.rules),
             Arg.ParsedArgs(shell.extra)
           )

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/.scalafix-explicit-run.conf
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/.scalafix-explicit-run.conf
@@ -1,0 +1,2 @@
+rules = [DisableSyntax]
+DisableSyntax.noReturns = true

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/.scalafix-on-compile.conf
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/.scalafix-on-compile.conf
@@ -1,0 +1,1 @@
+rules = [RemoveUnused]

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/.scalafix.conf
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/.scalafix.conf
@@ -1,0 +1,2 @@
+rules = [DisableSyntax]
+DisableSyntax.noNulls = true

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/build.sbt
@@ -1,0 +1,22 @@
+import _root_.scalafix.sbt.{BuildInfo => Versions}
+
+inThisBuild(
+  Seq(
+    scalaVersion := Versions.scala212,
+    scalacOptions ++= List(
+      "-Yrangepos",
+      "-Ywarn-unused"
+    )
+  )
+)
+
+lazy val example = project
+  .settings(
+    addCompilerPlugin(scalafixSemanticdb)
+  )
+
+lazy val noneScalafixConfig = project
+  .settings(
+    scalafixConfig := None,
+    addCompilerPlugin(scalafixSemanticdb)
+  )

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/example/src/main/scala/Example.scala
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/example/src/main/scala/Example.scala
@@ -1,0 +1,10 @@
+//can be removed by RemoveUnused
+import java.time.Instant
+
+object Example {
+  //can be removed by RemoveUnused
+  private val f: String = null
+
+  //cannot be removed by RemoveUnused
+  def g(): Unit = return
+}

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/noneScalafixConfig/src/main/scala/UnusedNull.scala
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/noneScalafixConfig/src/main/scala/UnusedNull.scala
@@ -1,0 +1,4 @@
+object UnusedNull {
+  //can be removed by RemoveUnused
+  private val f: String = null
+}

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
@@ -1,0 +1,37 @@
+# check if scalafix-on-compile is disabled
+
+> example/compile
+-> example/scalafix
+
+# check if scalafix-on-compile is enabled and uses .scalafix.conf
+
+> set scalafixOnCompile.in(ThisBuild) := true
+-> example/compile
+-> example/scalafix
+
+# check if scalafix-on-compile uses .scalafix-on-compile.conf
+#   and scalafix-explicit-run still uses .scalafix.conf
+
+> set scalafixOnCompileConfig.in(ThisBuild) := file(".scalafix-on-compile.conf"),
+-> example/scalafix
+-> example/scalafix --check RemoveUnused
+> example/compile
+## A statement incl. null has been removed by the precedence scalafix-on-compile.
+> example/scalafix
+
+# check if scalafix-on-compile uses .scalafix-on-compile.conf
+#   and scalafix-explicit-run uses .scalafix-explicit-run.conf
+
+> set scalafixConfig.in(ThisBuild) := Some(file(".scalafix-explicit-run.conf")),
+-> example/scalafix
+> example/compile
+
+# check if scalafix-on-compile uses .scalafix-on-compile.conf
+#   but scalafix-explicit-run uses .scalafix.conf because scalafixConfig is None
+
+-> noneScalafixConfig/scalafix
+-> noneScalafixConfig/scalafix --check RemoveUnused
+> noneScalafixConfig/compile
+## A statement incl. null has been removed by the precedence scalafix-on-compile.
+> noneScalafixConfig/scalafix
+

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
@@ -14,11 +14,12 @@
 
 > set scalafixOnCompileConfig.in(ThisBuild) := file(".scalafix-on-compile.conf"),
 -> example/scalafix --check
--> example/scalafix --check RemoveUnused
-$ copy-file example/src/main/scala/Example.scala noneScalafixConfig/src/test/scala/Original.scala
+-> example/scalafixOnCompileCheck
+$ copy-file example/src/main/scala/Example.scala noneScalafixConfig/src/test/scala/CopiedFile.scala
 > example/compile
-$ newer example/src/main/scala/Example.scala example/src/test/scala/Original.scala
+$ newer example/src/main/scala/Example.scala example/src/test/scala/CopiedFile.scala
 ## A statement incl. null has been removed by the precedence scalafix-on-compile.
+> example/scalafixOnCompileCheck
 > example/scalafix --check
 
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
@@ -26,18 +27,20 @@ $ newer example/src/main/scala/Example.scala example/src/test/scala/Original.sca
 
 > set scalafixConfig.in(example) := Some(file(".scalafix-explicit-run.conf"))
 -> example/scalafix --check
-$ touch example/src/test/scala/Original.scala
+> example/scalafixOnCompileCheck
+$ touch example/src/test/scala/CopiedFile.scala
 > example/compile
-$ newer example/src/test/scala/Original.scala example/src/main/scala/Example.scala
+$ newer example/src/test/scala/CopiedFile.scala example/src/main/scala/Example.scala
 
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
 #   but scalafix-explicit-run uses .scalafix.conf because scalafixConfig is None
 
 -> noneScalafixConfig/scalafix --check
--> noneScalafixConfig/scalafix --check RemoveUnused
-$ copy-file noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/src/test/scala/Original.scala
+-> noneScalafixConfig/scalafixOnCompileCheck
+$ copy-file noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/src/test/scala/CopiedFile.scala
 > noneScalafixConfig/compile
-$ newer noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/src/test/scala/Original.scala
+$ newer noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/src/test/scala/CopiedFile.scala
 ## A statement incl. null has been removed by the precedence scalafix-on-compile.
+> noneScalafixConfig/scalafixOnCompileCheck
 > noneScalafixConfig/scalafix --check
 

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
@@ -2,17 +2,19 @@
 
 > example/compile
 -> example/scalafix --check
+-> example/scalafixOnCompileCheck
 
 # check if scalafix-on-compile is enabled and uses .scalafix.conf
 
 > set scalafixOnCompile.in(ThisBuild) := true
 -> example/compile
 -> example/scalafix --check
+-> example/scalafixOnCompileCheck
 
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
 #   and scalafix-explicit-run still uses .scalafix.conf
 
-> set scalafixOnCompileConfig.in(ThisBuild) := file(".scalafix-on-compile.conf"),
+> set scalafixOnCompileConfig.in(ThisBuild) := file(".scalafix-on-compile.conf")
 -> example/scalafix --check
 -> example/scalafixOnCompileCheck
 $ copy-file example/src/main/scala/Example.scala noneScalafixConfig/src/test/scala/CopiedFile.scala
@@ -32,6 +34,11 @@ $ touch example/src/test/scala/CopiedFile.scala
 > example/compile
 $ newer example/src/test/scala/CopiedFile.scala example/src/main/scala/Example.scala
 
+# check if scalafixOnCompileCheck accepts shell arguments
+
+> noneScalafixConfig/scalafixOnCompileCheck --rules=DisableSyntax --settings.DisableSyntax.noThrows=true
+-> noneScalafixConfig/scalafixOnCompileCheck --rules=DisableSyntax --settings.DisableSyntax.noNulls=true
+
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
 #   but scalafix-explicit-run uses .scalafix.conf because scalafixConfig is None
 
@@ -43,4 +50,3 @@ $ newer noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/sr
 ## A statement incl. null has been removed by the precedence scalafix-on-compile.
 > noneScalafixConfig/scalafixOnCompileCheck
 > noneScalafixConfig/scalafix --check
-

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompileConfig/test
@@ -1,37 +1,43 @@
 # check if scalafix-on-compile is disabled
 
 > example/compile
--> example/scalafix
+-> example/scalafix --check
 
 # check if scalafix-on-compile is enabled and uses .scalafix.conf
 
 > set scalafixOnCompile.in(ThisBuild) := true
 -> example/compile
--> example/scalafix
+-> example/scalafix --check
 
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
 #   and scalafix-explicit-run still uses .scalafix.conf
 
 > set scalafixOnCompileConfig.in(ThisBuild) := file(".scalafix-on-compile.conf"),
--> example/scalafix
+-> example/scalafix --check
 -> example/scalafix --check RemoveUnused
+$ copy-file example/src/main/scala/Example.scala noneScalafixConfig/src/test/scala/Original.scala
 > example/compile
+$ newer example/src/main/scala/Example.scala example/src/test/scala/Original.scala
 ## A statement incl. null has been removed by the precedence scalafix-on-compile.
-> example/scalafix
+> example/scalafix --check
 
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
 #   and scalafix-explicit-run uses .scalafix-explicit-run.conf
 
-> set scalafixConfig.in(ThisBuild) := Some(file(".scalafix-explicit-run.conf")),
--> example/scalafix
+> set scalafixConfig.in(example) := Some(file(".scalafix-explicit-run.conf"))
+-> example/scalafix --check
+$ touch example/src/test/scala/Original.scala
 > example/compile
+$ newer example/src/test/scala/Original.scala example/src/main/scala/Example.scala
 
 # check if scalafix-on-compile uses .scalafix-on-compile.conf
 #   but scalafix-explicit-run uses .scalafix.conf because scalafixConfig is None
 
--> noneScalafixConfig/scalafix
+-> noneScalafixConfig/scalafix --check
 -> noneScalafixConfig/scalafix --check RemoveUnused
+$ copy-file noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/src/test/scala/Original.scala
 > noneScalafixConfig/compile
+$ newer noneScalafixConfig/src/main/scala/UnusedNull.scala noneScalafixConfig/src/test/scala/Original.scala
 ## A statement incl. null has been removed by the precedence scalafix-on-compile.
-> noneScalafixConfig/scalafix
+> noneScalafixConfig/scalafix --check
 


### PR DESCRIPTION
While I'm playing round scalafixOnCompile #140 now, I find a problem that may disturb current scalafix users to use RemoveUnused or OrganizeImports.

## Problem
Some of popular Scalafix rules like RemoveUnused or OrganizeImports work terribly with `scalafixOnCompile := true`.

Given the situation that `scalafixOnCompile` is true and RemoveUnused or OrganizeImports rules are effective,
writing an import statement and compiling it before adding a user code of the import, and then the import disappears.

Same problem exists in private or local variable with RemoveUnused rule.

Generally speaking, I believe Scalafix is great because its rules can vary in terms of their use-cases. Introducing `scalafix-on-compile` sounds great, because it might expand scalafix use-cases and can be an enabler to use scalafix as an extra linter like WartRemover.

Some rules can work great with scalafix-on-compilation already while there must be ones which are designed only for scalafix-explicit-run.

## Solution in this PR
So I'd think there must be a way to separate Scalafix rules between running explicitly and running on compile.

In this PR, I introduce scalafixConfingOnCompile settingKey to specify alternative `.scalafix.conf` which will be used only in `onCompile`.
At default, scalafixConfigOnCompile points to scalafixConfig so it won't affect users who don't need alternative `.scalafix.conf`.

If there is better way to solve the problem, please feel free to let me know. Your feedback is welcome.