### PR TITLE
fix usage of scalafix via another task

### DIFF
--- a/src/sbt-test/sbt-scalafix/wrapper/.scalafix.conf
+++ b/src/sbt-test/sbt-scalafix/wrapper/.scalafix.conf
@@ -1,0 +1,1 @@
+rules = [RemoveUnused]

--- a/src/sbt-test/sbt-scalafix/wrapper/build.sbt
+++ b/src/sbt-test/sbt-scalafix/wrapper/build.sbt
@@ -1,0 +1,5 @@
+val V = _root_.scalafix.sbt.BuildInfo
+
+scalaVersion := V.scala212
+addCompilerPlugin(scalafixSemanticdb)
+scalacOptions ++= Seq("-Yrangepos", "-Ywarn-unused")

--- a/src/sbt-test/sbt-scalafix/wrapper/project/LintAllPlugin.scala
+++ b/src/sbt-test/sbt-scalafix/wrapper/project/LintAllPlugin.scala
@@ -17,7 +17,7 @@ object LintAllPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
       lintAll := {
-        scalafixAll.toTask(" --check").value
+        scalafix.in(Compile).toTask(" --check").value
         // & other linters...
       }
     )

--- a/src/sbt-test/sbt-scalafix/wrapper/project/LintAllPlugin.scala
+++ b/src/sbt-test/sbt-scalafix/wrapper/project/LintAllPlugin.scala
@@ -1,0 +1,24 @@
+import sbt._
+import scalafix.sbt.ScalafixPlugin
+import scalafix.sbt.ScalafixPlugin.autoImport._
+
+object LintAllPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = ScalafixPlugin
+
+  object autoImport {
+    val lintAll = taskKey[Unit]("run all linters")
+  }
+
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      lintAll := {
+        scalafixAll.toTask(" --check").value
+        // & other linters...
+      }
+    )
+}

--- a/src/sbt-test/sbt-scalafix/wrapper/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/wrapper/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/wrapper/src/main/scala/example/Example.scala
+++ b/src/sbt-test/sbt-scalafix/wrapper/src/main/scala/example/Example.scala
@@ -1,0 +1,5 @@
+package example
+
+import imported.Imported
+
+object Example

--- a/src/sbt-test/sbt-scalafix/wrapper/src/main/scala/imported/Imported.scala
+++ b/src/sbt-test/sbt-scalafix/wrapper/src/main/scala/imported/Imported.scala
@@ -1,0 +1,3 @@
+package imported
+
+object Imported

--- a/src/sbt-test/sbt-scalafix/wrapper/test
+++ b/src/sbt-test/sbt-scalafix/wrapper/test
@@ -1,0 +1,14 @@
+# check that missing rewrites are detected, with or without a warm compilation cache
+> set scalafixOnCompile := false
+-> lintAll
+> compile
+-> lintAll
+
+# apply the rewrite via an explicit call
+> scalafix
+
+# confirms that `lintAll` sees that rewrite, with or without a warm compilation cache
+> clean
+> lintAll
+> compile
+> lintAll


### PR DESCRIPTION
Regression of 0cf5501: initial (cold) invocations to a task delegating to `scalafix` would result in `scalafix` being called before compilation (because `scalafixRunExplicitly == false`) causing false negatives.

This makes sure compilation is always triggered before `scalafix` (no matter how it's called), but depends on the final sub-tak of `compile` in a cycle-free way.