### PR TITLE
Respect Configuration in scalafixConfigSettings

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -96,12 +96,12 @@ object ScalafixPlugin extends AutoPlugin {
 
     def scalafixConfigSettings(config: Configuration): Seq[Def.Setting[_]] =
       Seq(
-        scalafix := scalafixInputTask(config).evaluated,
+        (scalafix in config) := scalafixInputTask(config).evaluated,
         (compile in config) := Def.taskDyn {
           val oldCompile =
             (compile in config).value // evaluated first, before the potential scalafix evaluation
-          if ((scalafixOnCompile in config).value)
-            scalafix
+          if (scalafixOnCompile.value)
+            (scalafix in config)
               .toTask("")
               .map(_ => oldCompile)
           else Def.task(oldCompile)

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -95,25 +95,26 @@ object ScalafixPlugin extends AutoPlugin {
       "org.scalameta" % "semanticdb-scalac" % scalametaVersion cross CrossVersion.full
 
     def scalafixConfigSettings(config: Configuration): Seq[Def.Setting[_]] =
-      Seq(
-        (scalafix in config) := scalafixInputTask(config).evaluated,
-        (compile in config) := Def.taskDyn {
-          val oldCompile =
-            (compile in config).value // evaluated first, before the potential scalafix evaluation
-          if (scalafixOnCompile.value)
-            (scalafix in config)
-              .toTask("")
-              .map(_ => oldCompile)
-          else Def.task(oldCompile)
-        }.value,
-        // In some cases (I haven't been able to understand when/why, but this also happens for bgRunMain while
-        // fgRunMain is fine), there is no specific streams attached to InputTasks, so  we they end up sharing the
-        // global streams, causing issues for cache storage. This does not happen for Tasks, so we define a dummy one
-        // to acquire a distinct streams instance for each InputTask.
-        scalafixDummyTask := (()),
-        streams.in(scalafix) := streams.in(scalafixDummyTask).value
+      inConfig(config)(
+        Seq(
+          scalafix := scalafixInputTask(config).evaluated,
+          compile := Def.taskDyn {
+            val oldCompile =
+              compile.value // evaluated first, before the potential scalafix evaluation
+            if (scalafixOnCompile.value)
+              scalafix
+                .toTask("")
+                .map(_ => oldCompile)
+            else Def.task(oldCompile)
+          }.value,
+          // In some cases (I haven't been able to understand when/why, but this also happens for bgRunMain while
+          // fgRunMain is fine), there is no specific streams attached to InputTasks, so  we they end up sharing the
+          // global streams, causing issues for cache storage. This does not happen for Tasks, so we define a dummy one
+          // to acquire a distinct streams instance for each InputTask.
+          scalafixDummyTask := (()),
+          streams.in(scalafix) := streams.in(scalafixDummyTask).value
+        )
       )
-
     @deprecated("This setting is no longer used", "0.6.0")
     val scalafixSourceroot: SettingKey[File] =
       settingKey[File]("Unused")

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -97,10 +97,10 @@ object ScalafixPlugin extends AutoPlugin {
     def scalafixConfigSettings(config: Configuration): Seq[Def.Setting[_]] =
       Seq(
         scalafix := scalafixInputTask(config).evaluated,
-        compile := Def.taskDyn {
+        (compile in config) := Def.taskDyn {
           val oldCompile =
-            compile.value // evaluated first, before the potential scalafix evaluation
-          if (scalafixOnCompile.value)
+            (compile in config).value // evaluated first, before the potential scalafix evaluation
+          if ((scalafixOnCompile in config).value)
             scalafix
               .toTask("")
               .map(_ => oldCompile)

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -20,13 +20,13 @@ inThisBuild(
 lazy val example = project
   .settings(
     Defaults.itSettings,
-    inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest)),
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions ++= List(
       "-Yrangepos",
       "-Ywarn-unused-import"
     )
   )
+  .settings(scalafixConfigSettings(IntegrationTest): _*)
 
 lazy val tests = project
 

--- a/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -32,7 +32,6 @@ lazy val scala212 = project
   .configs(IntegrationTest)
   .settings(
     Defaults.itSettings,
-    inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest)),
     unmanagedSources.in(Compile, scalafix) :=
       unmanagedSources
         .in(Compile)
@@ -41,6 +40,8 @@ lazy val scala212 = project
     scalaVersion := Versions.scala212,
     scalafixSettings
   )
+  .settings(scalafixConfigSettings(IntegrationTest): _*)
+
 lazy val javaProject = project.settings(
   scalaVersion := Versions.scala212,
   scalafixSettings

--- a/src/sbt-test/sbt-scalafix/inconfig/build.sbt
+++ b/src/sbt-test/sbt-scalafix/inconfig/build.sbt
@@ -17,9 +17,9 @@ inThisBuild(
 lazy val example = project
   .settings(
     Defaults.itSettings,
-    inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest)),
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions += "-Yrangepos"
   )
+  .settings(scalafixConfigSettings(IntegrationTest): _*)
 
 lazy val tests = project

--- a/src/sbt-test/sbt-scalafix/scalafixOnCompile/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixOnCompile/build.sbt
@@ -18,6 +18,6 @@ lazy val rewrite = project
   .configs(IntegrationTest)
   .settings(
     Defaults.itSettings,
-    inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest)),
     addCompilerPlugin(scalafixSemanticdb)
   )
+  .settings(scalafixConfigSettings(IntegrationTest): _*)


### PR DESCRIPTION
Hello - 

Upgrading to sbt-scalafix 0.9.19 caused one of my projects to fail. When poking around, I noticed that the new `scalafixOnCompile` configuration setup did not respect the configuration that was passed into the `scalafixConfigSettings` function. 

The scripted test got around this by doing `inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest))`. You should be able to just do ` scalafixConfigSettings(IntegrationTest)`. 

This PR updates the `scalafixConfigSettings` function to respect the passed `Configuration` value for these items.