### PR TITLE
Change scalafixResolvers to come from Coursier defaults so can be overridden

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -180,13 +180,21 @@ object ScalafixPlugin extends AutoPlugin {
   override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
     scalafixConfig := None, // let scalafix-cli try to infer $CWD/.scalafix.conf
     scalafixOnCompile := false,
-    scalafixResolvers := Repository.defaults().asScala.toSeq ++ Seq(
-      coursierapi.MavenRepository
-        .of("https://oss.sonatype.org/content/repositories/public"),
-      coursierapi.MavenRepository.of(
-        "https://oss.sonatype.org/content/repositories/snapshots"
-      )
-    ),
+    scalafixResolvers :=
+      // Repository.defaults() defaults to Repository.ivy2Local() and Repository.central(). These can be overridden per
+      // env variable, e.g., export COURSIER_REPOSITORIES="ivy2Local|central|sonatype:releases|jitpack|https://corporate.com/repo".
+      // See https://github.com/coursier/coursier/blob/master/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala#L19-L68
+      // and https://get-coursier.io/docs/other-repositories for more details.
+      // Also see src/sbt-test/sbt-scalafix/scalafixResolvers/test for a scripted test preserving this behavior.
+      Repository.defaults().asScala.toSeq ++
+        Seq(
+          coursierapi.MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/public"
+          ),
+          coursierapi.MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/snapshots"
+          )
+        ),
     scalafixDependencies := Nil,
     commands += ScalafixEnable.command,
     scalafixInterfaceProvider := ScalafixInterface.fromToolClasspath(

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -15,6 +15,7 @@ import scalafix.interfaces.ScalafixError
 import scalafix.internal.sbt.Arg.ToolClasspath
 import scalafix.internal.sbt._
 
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 import scala.util.Try
 import scala.util.control.NoStackTrace
 
@@ -179,9 +180,7 @@ object ScalafixPlugin extends AutoPlugin {
   override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
     scalafixConfig := None, // let scalafix-cli try to infer $CWD/.scalafix.conf
     scalafixOnCompile := false,
-    scalafixResolvers := Seq(
-      Repository.ivy2Local(),
-      Repository.central(),
+    scalafixResolvers := Repository.defaults().asScala.toSeq ++ Seq(
       coursierapi.MavenRepository
         .of("https://oss.sonatype.org/content/repositories/public"),
       coursierapi.MavenRepository.of(

--- a/src/sbt-test/sbt-scalafix/scalafixResolvers/.env
+++ b/src/sbt-test/sbt-scalafix/scalafixResolvers/.env
@@ -1,0 +1,1 @@
+COURSIER_REPOSITORIES="ivy2Local|central|ivy:https://a.b.com/artifactory/snapshots/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"

--- a/src/sbt-test/sbt-scalafix/scalafixResolvers/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixResolvers/build.sbt
@@ -1,0 +1,29 @@
+scalaVersion := "2.12.7"
+
+TaskKey[Unit]("check") := {
+  val expectedRepositories: Seq[String] = Seq(
+    // Repository.central()
+    "https://repo1.maven.org/maven2",
+    //Repository.ivy2Local()
+    ".ivy2/local/",
+    "https://oss.sonatype.org/content/repositories/public",
+    "https://oss.sonatype.org/content/repositories/snapshots",
+    // custom repository
+    "https://a.b.com/artifactory/snapshots"
+  )
+
+  // scalafixResolvers is lazily evaluated as a stream of coursier.internal.api.ApiHelper.ApiRepo's. To fully evaluate
+  // the stream and overcome object equality issues, build a string from scalafixResolvers.
+  var scalafixRepos: String = ""
+  scalafixResolvers.in(ThisBuild).value.foreach { repo =>
+    scalafixRepos += repo.toString
+  }
+
+  expectedRepositories.foreach { repository =>
+    if (!scalafixRepos.contains(repository)) {
+      throw new Exception(
+        s"repository=$repository not included in scalafixResolvers"
+      )
+    }
+  }
+}

--- a/src/sbt-test/sbt-scalafix/scalafixResolvers/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixResolvers/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))
+addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.146")

--- a/src/sbt-test/sbt-scalafix/scalafixResolvers/test
+++ b/src/sbt-test/sbt-scalafix/scalafixResolvers/test
@@ -1,0 +1,3 @@
+# reload to ensure env variable COURSIER_REPOSITORIES is picked up by scalafixResolvers
+> reload
+> check


### PR DESCRIPTION
The impetus for this proposed change is trying to use privately hosted `scalafix` rules with [`scala-steward`](https://github.com/scala-steward-org/scala-steward). Currently, the scalafix tutorial describes how to [add custom scalafix resolvers](https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#adding-custom-resolver) in a project's `build.sbt`. Since scala-steward adds the sbt-scalafix plugin on the fly, however, it would further need to edit a project's `build.sbt` in order to add custom resolvers, which would be tricky.

The alternative I'm proposing here sets the `scalafixResolvers` to Coursier's [`defaultRepositories`](https://github.com/coursier/coursier/blob/master/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala#L19).  The [defaults](https://github.com/coursier/coursier/blob/master/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala#L60-L63) are the same as previously set - `Repository.ivy2Local()` and `Repository.central()`. But using `defaultRepositories` allows overriding the repositories via the `COURSIER_REPOSITORIES` environment variable, as documented [here](https://get-coursier.io/docs/other-repositories) and shown in the `defaultRepositories` code.

I've tested this code locally with first doing 
```
export COURSIER_REPOSITORIES="ivy2Local|central|ivy:https://a.b.c/d/f/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
```
and then running `sbt-scalafix` on a repo (without overriding the `scalafixResolvers`), and verified it picks up the `scalafix` rules which exist only in the private ivy artifactory resolver.

When trying to run `scala-steward` to apply the privately hosted `scalafix` rules, the current error I'm getting is:
```
13:21:47  [error] (root/*:scalafixAll) scalafix.sbt.InvalidArgument: Failed to fetch [Dependency(Module(a.b.c, scalafix_2.12), 0.0.1-12-f9db091-SNAPSHOT)]from [IvyRepository(file:/home/user/.ivy2/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], dropInfoAttributes = true), MavenRepository(https://repo1.maven.org/maven2), MavenRepository(https://oss.sonatype.org/content/repositories/public), MavenRepository(https://oss.sonatype.org/content/repositories/snapshots)]
```
which I expect this proposed change to resolve. If this change is accepted, I will update the [`scala-steward` running docs](https://github.com/scala-steward-org/scala-steward/blob/master/docs/running.md#private-repositories) to explain how adding `export COURSIER_REPOSITORIES="ivy2Local|central|somePrivateRepository"` before running `scala-steward` allows applying privately hosted `scala-fix` rules.