### PR TITLE
sbt 1.4.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -97,7 +97,11 @@ object ScalafixPlugin extends AutoPlugin {
     def scalafixConfigSettings(config: Configuration): Seq[Def.Setting[_]] =
       inConfig(config)(
         Seq(
-          scalafix := scalafixInputTask(config).evaluated,
+          scalafix := {
+            // force detection of usage of `scalafixCaching` to workaround https://github.com/sbt/sbt/issues/5647
+            val _ = scalafixCaching.?.value
+            scalafixInputTask(config).evaluated
+          },
           compile := Def.taskDyn {
             val oldCompile =
               compile.value // evaluated first, before the potential scalafix evaluation


### PR DESCRIPTION
The second commit works around https://github.com/sbt/sbt/issues/5647, which can be observed when the client uses sbt 1.4.0 (independently of the version we build with/against here) and defines `scalafixCaching`.