### PR TITLE
support running scalafix on projects with sources at the root

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -175,7 +175,9 @@ object ScalafixPlugin extends AutoPlugin {
 
   override lazy val projectSettings: Seq[Def.Setting[_]] =
     Seq(Compile, Test).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
-      inConfig(ScalafixConfig)(Defaults.configSettings) ++
+      inConfig(ScalafixConfig)(
+        Defaults.configSettings :+ (sourcesInBase := false)
+      ) ++
       Seq(
         ivyConfigurations += ScalafixConfig,
         scalafixAll := scalafixAllInputTask.evaluated

--- a/src/sbt-test/sbt-scalafix/custom-src-directory/app/ProcedureSyntax.scala
+++ b/src/sbt-test/sbt-scalafix/custom-src-directory/app/ProcedureSyntax.scala
@@ -1,0 +1,3 @@
+object ProcedureSyntax {
+  def unit {}
+}

--- a/src/sbt-test/sbt-scalafix/custom-src-directory/build.sbt
+++ b/src/sbt-test/sbt-scalafix/custom-src-directory/build.sbt
@@ -1,0 +1,3 @@
+val app = project.settings(
+  scalaSource.in(Compile) := baseDirectory.value
+)

--- a/src/sbt-test/sbt-scalafix/custom-src-directory/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/custom-src-directory/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/custom-src-directory/test
+++ b/src/sbt-test/sbt-scalafix/custom-src-directory/test
@@ -1,0 +1,3 @@
+-> app/scalafix --test ProcedureSyntax
+> app/scalafix ProcedureSyntax
+> app/scalafix --test ProcedureSyntax


### PR DESCRIPTION
When defining local rules using the Scalafix configuration, libraryDependencies must be defined, as documented in: https://scalacenter.github.io/scalafix/docs/developers/local-rules.html. We could add it by default, but it would unnecessarily clutter the update task in 99.9% of the plugin use cases.

When projects have a custom directory layout (via scalaSource), users could not know that Scalafix settings would need to be updated to exclude sources potentially at the root (sourcesInBase), in order to prevent compilation errors as Scalafix does not have the Scala libs, causing:
> scala.reflect.internal.MissingRequirementError: object scala in compiler mirror not found.

This commit disables sourcesInBase by default to prevent this, as the local rules have no reason to share code with other default configurations anyway.