### PR TITLE
Toward a machine-independent incremental cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.bsp
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -92,5 +92,6 @@ sbtPlugin := true
 scriptedBufferLog := false
 scriptedLaunchOpts ++= Seq(
   "-Xmx2048M",
-  s"-Dplugin.version=${version.value}"
+  s"-Dplugin.version=${version.value}",
+  "-Dsbt-scalafix.uselastmodified=true" // the caching scripted relies on sbt-scalafix only checking file attributes, not content
 )

--- a/src/main/scala-sbt-0.13/sbt/internal/sbtscalafix/Caching.scala
+++ b/src/main/scala-sbt-0.13/sbt/internal/sbtscalafix/Caching.scala
@@ -11,6 +11,7 @@ import scala.util.DynamicVariable
 object Caching {
 
   val lastModifiedStyle = FilesInfo.lastModified
+  val hashStyle = FilesInfo.hash
 
   trait CacheKeysStamper
       extends InputCache[Seq[Arg.CacheKey]]

--- a/src/main/scala-sbt-1.0/sbt/internal/sbtscalafix/Caching.scala
+++ b/src/main/scala-sbt-1.0/sbt/internal/sbtscalafix/Caching.scala
@@ -9,6 +9,7 @@ import scala.util.DynamicVariable
 object Caching {
 
   val lastModifiedStyle = FileInfo.lastModified
+  val hashStyle = FileInfo.hash
 
   trait CacheKeysStamper
       extends JsonFormat[Seq[Arg.CacheKey]]

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -492,7 +492,7 @@ object ScalafixPlugin extends AutoPlugin {
                 case jar =>
                   Seq(jar)
               }
-            write(files.map(FileInfo.lastModified.apply))
+            write(files.map(stampFile))
             write(customDependencies.map(_.toString))
           case Arg.Rules(rules) =>
             rules.foreach {
@@ -509,10 +509,10 @@ object ScalafixPlugin extends AutoPlugin {
           case Arg.Config(maybeFile) =>
             maybeFile match {
               case Some(path) =>
-                write(FileInfo.lastModified(path.toFile))
+                write(stampFile(path.toFile))
               case None =>
                 val defaultConfigFile = file(".scalafix.conf")
-                write(FileInfo.lastModified(defaultConfigFile))
+                write(stampFile(defaultConfigFile))
             }
           case Arg.ParsedArgs(args) =>
             val cacheKeys = args.filter {
@@ -534,6 +534,14 @@ object ScalafixPlugin extends AutoPlugin {
             write(cacheKeys)
           case Arg.NoCache =>
             throw StampingImpossible
+        }
+
+        def stampFile(file: File): Array[Byte] = {
+          // ensure the file exists and is not a directory
+          if (file.isFile)
+            Hash(file)
+          else
+            Array.empty[Byte]
         }
       }
 


### PR DESCRIPTION
The objective is to produce a machine-independent cache in order to include sbt-scalafix cache files in the [remote cache artifact](https://www.scala-sbt.org/1.x/docs/Remote-Caching.html).
Two things are missing:

1. Cache stamps must be persisted with relative paths instead of absolute paths (https://github.com/sbt/sbt/issues/6298)
1. sbt-scalafix have to use `hash` instead of `lastModified` style for cache stamping.

This PR solves the second point.

To make the scripted tests green, i had to permit to get back the previous behaviour (`lastModified`). Done with a system property.
