### PR TITLE
Deterministic `args` file stamp

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -492,8 +492,8 @@ object ScalafixPlugin extends AutoPlugin {
                 case jar =>
                   Seq(jar)
               }
-            write(files.map(stampFile))
-            write(customDependencies.map(_.toString))
+            write(files.map(stampFile).sorted)
+            write(customDependencies.map(_.toString).sorted)
           case Arg.Rules(rules) =>
             rules.foreach {
               case source
@@ -536,12 +536,12 @@ object ScalafixPlugin extends AutoPlugin {
             throw StampingImpossible
         }
 
-        def stampFile(file: File): Array[Byte] = {
+        def stampFile(file: File): String = {
           // ensure the file exists and is not a directory
           if (file.isFile)
-            Hash(file)
+            Hash.toHex(Hash(file))
           else
-            Array.empty[Byte]
+            ""
         }
       }
 


### PR DESCRIPTION
Since https://github.com/scalacenter/sbt-scalafix/pull/188 the scalafix is _almost_ machine-independent but we discovered that the `args` was not determinist across machines. 
This PR fixes this issue by sorting the classpath and the dependencies before hashing them.