### PR TITLE
scalafixEnable: relax -Xfatal-warnings for scalafix invocations

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixEnable.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixEnable.scala
@@ -3,6 +3,7 @@ package scalafix.sbt
 import sbt._
 import sbt.Keys._
 import sbt.internal.sbtscalafix.Compat
+import ScalafixPlugin.autoImport._
 
 /** Command to automatically enable semanticdb-scalac for shell session */
 object ScalafixEnable {
@@ -36,18 +37,29 @@ object ScalafixEnable {
       "Configure libraryDependencies, scalaVersion and scalacOptions for scalafix.",
     detail = """1. enables the semanticdb-scalac compiler plugin
       |2. sets scalaVersion to latest Scala version supported by scalafix
-      |3. add -Yrangepos to scalacOptions""".stripMargin
+      |3. add -Yrangepos to scalacOptions
+      |4. relax -Xfatal-warnings, -Werror & -Wconf* (if set in scalacOptions) for upcoming scalafix invocations""".stripMargin
   ) { s =>
     val extracted = Project.extract(s)
     val settings: Seq[Setting[_]] = for {
       (p, fullVersion) <- projectsWithMatchingScalaVersion(s)
-      isEnabled =
+      relaxScalacForScalafix <- List(
+        scalacOptions.in(p) := {
+          val options = scalacOptions.in(p).value
+          if (!scalafixInvoked.value) options
+          else
+            options.filterNot { option =>
+              List("-Xfatal-warnings", "-Werror").contains(option) ||
+              option.startsWith("-Wconf")
+            }
+        }
+      )
+      isSemanticdbEnabled =
         libraryDependencies
           .in(p)
           .get(extracted.structure.data)
           .exists(_.exists(_.name == "semanticdb-scalac"))
-      if !isEnabled
-      setting <- List(
+      addSemanticdb <- List(
         scalaVersion.in(p) := fullVersion,
         scalacOptions.in(p) ++= List(
           "-Yrangepos",
@@ -57,10 +69,16 @@ object ScalafixEnable {
           ScalafixPlugin.autoImport.scalafixSemanticdb
         )
       )
-    } yield setting
+      settings <-
+        relaxScalacForScalafix ++
+          (if (!isSemanticdbEnabled) addSemanticdb else List())
+    } yield settings
 
-    val semanticdbInstalled = Compat.append(extracted, settings, s)
+    val scalafixReady = Compat.append(extracted, settings, s)
 
-    semanticdbInstalled
+    scalafixReady
   }
+
+  private def scalafixInvoked: Def.Initialize[Task[Boolean]] =
+    Def.task(executionRoots.value.exists(_.key == scalafix.key))
 }

--- a/src/main/scala/scalafix/sbt/ScalafixEnable.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixEnable.scala
@@ -80,5 +80,12 @@ object ScalafixEnable {
   }
 
   private def scalafixInvoked: Def.Initialize[Task[Boolean]] =
-    Def.task(executionRoots.value.exists(_.key == scalafix.key))
+    Def.task {
+      executionRoots.value.exists { root =>
+        Seq(
+          scalafix.key,
+          scalafixAll.key
+        ).contains(root.key)
+      }
+    }
 }

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
@@ -21,7 +21,16 @@ lazy val scala211 = project.settings(
 
 // 2.12.x is supported
 lazy val scala212 = project.settings(
-  scalaVersion := V.scala212
+  scalaVersion := V.scala212,
+  scalacOptions ++= Seq(
+    // generate errors on unused imports
+    "-Xfatal-warnings",
+    "-Ywarn-unused",
+    // generate errors on procedure syntax
+    "-Wconf:cat=deprecation:e",
+    "-Xfuture",
+    "-deprecation"
+  )
 )
 
 // 2.13.x is supported

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/scala212/src/main/scala/UnusedImportAndProcedureSyntax.scala
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/scala212/src/main/scala/UnusedImportAndProcedureSyntax.scala
@@ -1,0 +1,4 @@
+object UnusedImportAndProcedureSyntax {
+  import java.util.Calendar
+  def main {}
+}

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/test
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/test
@@ -6,7 +6,7 @@
 -> scala212/compile
 
 # ensure that a semantic rule can be ran despite warnings, to fix one of the warning
-> scala212/scalafix RemoveUnused
+> scala212/scalafixAll RemoveUnused
 
 # but that -Xfatal-warnings remains honored for regular compilation
 -> scala212/compile

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/test
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/test
@@ -1,3 +1,16 @@
 -> check
 > scalafixEnable
 > check
+
+# we have 2 fatal warnings preventing compilation
+-> scala212/compile
+
+# ensure that a semantic rule can be ran despite warnings, to fix one of the warning
+> scala212/scalafix RemoveUnused
+
+# but that -Xfatal-warnings remains honored for regular compilation
+-> scala212/compile
+
+# confirm that compilation succeeds after fixing the last warning
+> scala212/scalafix ProcedureSyntax
+> scala212/compile


### PR DESCRIPTION
Closes https://github.com/scalacenter/scalafix/issues/1346

`scalafixEnable` should maximize the chances of getting `semanticdb-scalac` to run so that semantic rules can run.

When enabled in the build, `-Xfatal-warnings` can be a major obstacle for example when:
1. `scalafixEnable` forced a newer (patch) Scala version that the one in the build, with improved warning reporting;
2. the user already has a build with fatal deprecation warnings and wants to apply a rewrite rule to fix them.