### PR TITLE
scalafixEnable: support builds overriding scalacOptions

### DIFF
--- a/src/main/scala-sbt-0.13/sbt/internal/sbtscalafix/Compat.scala
+++ b/src/main/scala-sbt-0.13/sbt/internal/sbtscalafix/Compat.scala
@@ -1,6 +1,6 @@
 package sbt.internal.sbtscalafix
 
-import sbt.{Compiler, Extracted, Setting, State}
+import sbt.{Classpaths, Compiler, Extracted, Setting, State, UpdateReport}
 import sbt.inc.IncOptions
 
 object Compat {
@@ -29,5 +29,16 @@ object Compat {
       hasModified: Boolean
   ): Compiler.CompileResult = {
     compileResult
+  }
+
+  def autoPlugins(
+      report: UpdateReport,
+      scalaVersion: String
+  ): Seq[String] = {
+    Classpaths.autoPlugins(
+      report,
+      Seq(),
+      Set("jar", "bundle")
+    )
   }
 }

--- a/src/main/scala-sbt-1.0/sbt/internal/sbtscalafix/Compat.scala
+++ b/src/main/scala-sbt-1.0/sbt/internal/sbtscalafix/Compat.scala
@@ -1,6 +1,7 @@
 package sbt.internal.sbtscalafix
 
-import sbt.{Extracted, IncOptions, Setting, State}
+import sbt.internal.inc.ScalaInstance
+import sbt.{Classpaths, Extracted, IncOptions, Setting, State, UpdateReport}
 import xsbti.compile.CompileResult
 
 object Compat {
@@ -31,5 +32,16 @@ object Compat {
       hasModified: Boolean
   ): CompileResult = {
     compileResult.withHasModified(hasModified)
+  }
+
+  def autoPlugins(
+      report: UpdateReport,
+      scalaVersion: String
+  ): Seq[String] = {
+    Classpaths.autoPlugins(
+      report,
+      Seq(),
+      ScalaInstance.isDotty(scalaVersion)
+    )
   }
 }

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
@@ -33,14 +33,34 @@ TaskKey[Unit]("check") := {
   // nothing should change for the 2.10 project
   assert(scalaVersion.in(scala210).value == "2.10.4")
   assert(libraryDependencies.in(scala210).value.isEmpty)
-  assert(scalacOptions.in(scala210).value.isEmpty)
+  assert(scalacOptions.in(scala210, Compile, compile).value.isEmpty)
 
   // 2.12.0 should be overidden to 2.12.X
   assert(scalaVersion.in(overridesSettings).value == V.scala212)
   assert(libraryDependencies.in(overridesSettings).value.nonEmpty)
-  assert(scalacOptions.in(overridesSettings).value.contains("-Yrangepos"))
+  assert(
+    scalacOptions
+      .in(overridesSettings, Compile, compile)
+      .value
+      .contains("-Yrangepos")
+  )
 
-  assert(scalacOptions.in(scala211).value.count(_ == "-Yrangepos") == 1)
-  assert(scalacOptions.in(scala212).value.count(_ == "-Yrangepos") == 1)
-  assert(scalacOptions.in(scala213).value.count(_ == "-Yrangepos") == 1)
+  assert(
+    scalacOptions
+      .in(scala211, Compile, compile)
+      .value
+      .count(_ == "-Yrangepos") == 1
+  )
+  assert(
+    scalacOptions
+      .in(scala212, Compile, compile)
+      .value
+      .count(_ == "-Yrangepos") == 1
+  )
+  assert(
+    scalacOptions
+      .in(scala213, Test, compile)
+      .value
+      .count(_ == "-Yrangepos") == 1
+  )
 }

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/project/FatalWarningsPlugin.scala
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/project/FatalWarningsPlugin.scala
@@ -12,7 +12,7 @@ object FatalWarningsPlugin extends AutoPlugin {
   override def requires: Plugins = ScalafixPlugin
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    scalacOptions.in(Test, compile) ++= Seq(
+    scalacOptions.in(Test, compile) := Seq(
       "-Xfatal-warnings",
       "-Ywarn-unused"
     )


### PR DESCRIPTION
Also, scalacOptions are now set in a more specific scope (matching the one looked up for compiler invocation so that scalafixEnable overrides them no matter at which scope they are defined), so assertions had to be updated.

Fixes https://github.com/scalacenter/scalafix/issues/1306