### PR TITLE
make it possible to and do build against a scalafix SNAPSHOT

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   val x = List(1) // scalafix:ok
-  // when bumping remove dep on SNAPSHOT in sbt-1.5 scripted tests
-  def scalafixVersion: String = "0.9.27"
+  def scalafixVersion: String = "0.9.27+52-6c9eeec9-SNAPSHOT"
+
   val all = List(
     "org.eclipse.jgit" % "org.eclipse.jgit" % "5.11.0.202103091610-r",
     "ch.epfl.scala" % "scalafix-interfaces" % scalafixVersion,

--- a/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
@@ -27,6 +27,11 @@ object ScalafixTestkitPlugin extends AutoPlugin {
   }
   import autoImport._
 
+  override def buildSettings: Seq[Def.Setting[_]] =
+    List(
+      resolvers += Resolver.sonatypeRepo("snapshots")
+    )
+
   override def projectSettings: Seq[Def.Setting[_]] =
     List(
       scalafixTestkitInputScalacOptions := scalacOptions.value,

--- a/src/sbt-test/sbt-1.3/semanticdb-enabled/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.3/semanticdb-enabled/project/plugins.sbt
@@ -1,1 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-1.3/testkit/tests/src/test/scala/fix/InputOutputSuite.scala
+++ b/src/sbt-test/sbt-1.3/testkit/tests/src/test/scala/fix/InputOutputSuite.scala
@@ -2,15 +2,16 @@ package fix
 
 import scalafix.testkit._
 import scala.util.control.NonFatal
+import org.scalatest.FunSuiteLike
 import org.scalatest.exceptions.TestFailedException
 
 object IntputOutputSuite {
   def main(args: Array[String]): Unit = {
     if (Array("--save-expect").sameElements(args)) {
-      val suite = new SemanticRuleSuite(
-        TestkitProperties.loadFromResources(),
-        isSaveExpect = true
-      ) {
+      val suite = new AbstractSemanticRuleSuite with FunSuiteLike {
+        override val props = TestkitProperties.loadFromResources()
+        override val isSaveExpect = true
+
         testsToRun.foreach { t =>
           try evaluateTestBody(t)
           catch {
@@ -29,6 +30,6 @@ object IntputOutputSuite {
   }
 }
 
-class IntputOutputSuite extends SemanticRuleSuite {
+class IntputOutputSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
   runAllTests()
 }

--- a/src/sbt-test/sbt-1.5/scala-3/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.5/scala-3/project/plugins.sbt
@@ -1,6 +1,2 @@
 resolvers += Resolver.sonatypeRepo("public")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))
-
-//FIXME: remove when scalafixVersion is bumped to 0.9.28
-resolvers += Resolver.sonatypeRepo("snapshots")
-dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "0.9.27+52-6c9eeec9-SNAPSHOT"

--- a/src/sbt-test/sbt-1.5/scalafixEnable/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.5/scalafixEnable/project/plugins.sbt
@@ -1,6 +1,2 @@
 resolvers += Resolver.sonatypeRepo("public")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))
-
-//FIXME: remove when scalafixVersion is bumped to 0.9.28
-resolvers += Resolver.sonatypeRepo("snapshots")
-dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "0.9.27+52-6c9eeec9-SNAPSHOT"

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -12,8 +12,7 @@ inThisBuild(
     scalafixDependencies := List(
       // Custom rule published to Maven Central https://github.com/scalacenter/example-scalafix-rule
       "ch.epfl.scala" %% "example-scalafix-rule" % "1.4.0"
-    ),
-    scalafixResolvers := List(Repository.MavenCentral)
+    )
   )
 )
 

--- a/src/sbt-test/sbt-scalafix/concurrency/build.sbt
+++ b/src/sbt-test/sbt-scalafix/concurrency/build.sbt
@@ -1,6 +1,7 @@
 val V = _root_.scalafix.sbt.BuildInfo
 
 scalaVersion := V.scala212
+resolvers += Resolver.sonatypeRepo("snapshots")
 libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion % ScalafixConfig
 
 // make it possible to run scalafix in parallel with other tasks via the `all` command

--- a/src/sbt-test/sbt-scalafix/local-rules/build.sbt
+++ b/src/sbt-test/sbt-scalafix/local-rules/build.sbt
@@ -6,11 +6,7 @@ inThisBuild(
       // Custom rule cross-published to Maven Central https://github.com/scalacenter/example-scalafix-rule
       "ch.epfl.scala" %% "example-scalafix-rule" % "1.4.0"
     ),
-    // `Repository.central()` can only be used sbt 1.x / scala 2.12
-    // error: Static methods in interface require -target:jvm-1.8
-    scalafixResolvers := List(
-      coursierapi.MavenRepository.of("https://repo1.maven.org/maven2")
-    ),
+    resolvers += Resolver.sonatypeRepo("snapshots"),
     scalaVersion := "2.13.0", // out of sync with scalafix.sbt.BuildInfo.scala213 on purpose
     scalafixScalaBinaryVersion :=
       // this should be the default in sbt-scalafix 1.0

--- a/src/sbt-test/sbt-scalafix/testkit/tests/src/test/scala/fix/InputOutputSuite.scala
+++ b/src/sbt-test/sbt-scalafix/testkit/tests/src/test/scala/fix/InputOutputSuite.scala
@@ -2,15 +2,16 @@ package fix
 
 import scalafix.testkit._
 import scala.util.control.NonFatal
+import org.scalatest.FunSuiteLike
 import org.scalatest.exceptions.TestFailedException
 
 object IntputOutputSuite {
   def main(args: Array[String]): Unit = {
     if (Array("--save-expect").sameElements(args)) {
-      val suite = new SemanticRuleSuite(
-        TestkitProperties.loadFromResources(),
-        isSaveExpect = true
-      ) {
+      val suite = new AbstractSemanticRuleSuite with FunSuiteLike {
+        override val props = TestkitProperties.loadFromResources()
+        override val isSaveExpect = true
+
         testsToRun.foreach { t =>
           try evaluateTestBody(t)
           catch {
@@ -29,6 +30,6 @@ object IntputOutputSuite {
   }
 }
 
-class IntputOutputSuite extends SemanticRuleSuite {
+class IntputOutputSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
   runAllTests()
 }

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -1,6 +1,6 @@
 package scalafix.internal.sbt
 
-import coursierapi.Repository
+import coursierapi.{MavenRepository, Repository}
 import org.eclipse.jgit.lib.AbbreviatedObjectId
 import org.scalatest.Tag
 import sbt.complete.Parser
@@ -32,7 +32,12 @@ class SbtCompletionsSuite extends AnyFunSuite {
       .fromToolClasspath(
         "2.12",
         Seq(exampleDependency),
-        Seq(Repository.central)
+        Seq(
+          Repository.central,
+          MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/snapshots"
+          )
+        )
       )()
   val loadedRules = mainArgs.availableRules.toList
 

--- a/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
@@ -3,7 +3,7 @@ package scalafix.internal.sbt
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.file.Files
 
-import coursierapi.Repository
+import coursierapi.{MavenRepository, Repository}
 import org.scalactic.source.Position
 import sbt._
 import sbt.internal.sbtscalafix.Compat
@@ -31,7 +31,12 @@ class ScalafixAPISuite extends AnyFunSuite {
       .fromToolClasspath(
         "2.12",
         List("ch.epfl.scala" %% "example-scalafix-rule" % "1.4.0"),
-        Seq(Repository.central),
+        Seq(
+          Repository.central,
+          MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/snapshots"
+          )
+        ),
         logger
       )()
       .withArgs(Arg.PrintStream(new PrintStream(baos)))


### PR DESCRIPTION
Follows https://github.com/scalacenter/sbt-scalafix/pull/210

It's useful to build and run all scripted tests against a scalafix SNAPSHOT to avoid getting (late) surprises during the 2-step (scalafix/sbt-scalafix) release phase.

Most of the users running SNAPSHOT versions of sbt-scalafix should be able to use one that depends on a SNAPSHOT scalafix since they must already have sonatype snapshots in the metabuild and the default `scalafixResolvers` will re-resolve scalafix through sonatype snapshots via the embedded coursier.