### PR TITLE
enable scalafixCaching by default

### DIFF
--- a/src/sbt-test/skip-windows/caching/build.sbt
+++ b/src/sbt-test/skip-windows/caching/build.sbt
@@ -6,7 +6,6 @@ inThisBuild(
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions += "-Yrangepos",
     scalacOptions += "-Ywarn-unused", // for RemoveUnused
-    scalafixCaching := true,
     scalafixDependencies += "com.geirsson" %% "example-scalafix-rule" % "1.2.0",
     resolvers +=
       // for retrieving SNAPSHOTS of `scalafix-interfaces`


### PR DESCRIPTION
The lack of bug reports over the last year or so, despite usage of it through `scalafixOnCompile` (see https://github.com/scalacenter/scalafix/issues/1164#issuecomment-791379286 & https://github.com/search?p=3&q=scalafixOnCompile&type=Code) makes me believe the feature is mature enough for prime time. In real life, we never experienced the false positive mentioned in https://github.com/scalacenter/scalafix/issues/1164#issue-639185750, and since CI should run on a clean slate anyway, I think it's safe to say that it's only a theoretical concern.

Ideally, it should move to upstream scalafix, but handling state & file stamping without sbt helpers is far from trivial.