### PR TITLE
print actionnable error when trying to resolve Scala 3 scalafix

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -135,6 +135,12 @@ object ScalafixInterface {
       logger: Logger = Compat.ConsoleLogger(System.out)
   ): () => ScalafixInterface =
     new LazyValue({ () =>
+      if (scalafixBinaryScalaVersion.startsWith("3"))
+        logger.error(
+          "To use Scalafix on Scala 3 projects, you must unset `scalafixBinaryScalaVersion`. " +
+            "Rules such as ExplicitResultTypes requiring the project version to match the Scalafix " +
+            "version are unsupported for the moment."
+        )
       val callback = new ScalafixLogger(logger)
       val scalafixArguments = ScalafixAPI
         .fetchAndClassloadInstance(

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -232,7 +232,7 @@ object ScalafixPlugin extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] =
     Seq(
-      scalafixScalaBinaryVersion := "2.12" // scalaBinaryVersion.value for 1.0
+      scalafixScalaBinaryVersion := "2.12"
     )
 
   lazy val stdoutLogger = Compat.ConsoleLogger(System.out)


### PR DESCRIPTION
We are backpedaling from https://github.com/scalacenter/scalafix/issues/1108#issuecomment-647402044 at the light of the strategy we will most likely chose for `ExplicitResultTypes` on Scala 3: https://github.com/scalacenter/scalafix/issues/1316.