### PR TITLE
Disable BSP in Scalafix config

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -183,15 +183,20 @@ object ScalafixPlugin extends AutoPlugin {
   override lazy val projectConfigurations: Seq[Configuration] =
     Seq(ScalafixConfig)
 
-  override lazy val projectSettings: Seq[Def.Setting[_]] =
-    Seq(Compile, Test).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
-      inConfig(ScalafixConfig)(
-        Defaults.configSettings :+ (sourcesInBase := false)
-      ) ++
-      Seq(
-        ivyConfigurations += ScalafixConfig,
-        scalafixAll := scalafixAllInputTask.evaluated
+  override lazy val projectSettings: Seq[Def.Setting[_]] = Def.settings(
+    Seq(Compile, Test).flatMap(c => inConfig(c)(scalafixConfigSettings(c))),
+    inConfig(ScalafixConfig)(
+      Def.settings(
+        Defaults.configSettings,
+        sourcesInBase := false,
+        // local copy of https://github.com/sbt/sbt/blob/e4231ac03903e174bc9975ee00d34064a1d1f373/main/src/main/scala/sbt/Keys.scala#L400
+        // so that it does not break on sbt version below 1.4.0
+        SettingKey[Boolean]("bspEnabled") := false
       )
+    ),
+    ivyConfigurations += ScalafixConfig,
+    scalafixAll := scalafixAllInputTask.evaluated
+  )
 
   override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
     scalafixConfig := None, // let scalafix-cli try to infer $CWD/.scalafix.conf


### PR DESCRIPTION
The Scalafix config adds a BSP build target that is useless because it has no sources.

This PR disables BSP in the Scalafix config so that it is never exported to the IDE. The implementation involves a bit of reflection to deal with the compatibility issue on old versions of sbt.

See also:
- https://github.com/sbt/sbt/issues/6546
- https://github.com/scalameta/metals/pull/2895