### PR TITLE
Add more fine grained check for `scalacOptionsToRelax`

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -732,5 +732,5 @@ object ScalafixPlugin extends AutoPlugin {
     }
 
   private val scalacOptionsToRelax =
-    List("-Xfatal-warnings", "-Werror", "-Wconf.*").map(_.r.pattern)
+    List("-Xfatal-warnings", "-Werror", "-Wconf.*:(e|error)").map(_.r.pattern)
 }

--- a/src/sbt-test/sbt-scalafix/relax-scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-scalafix/relax-scalacOptions/build.sbt
@@ -12,6 +12,8 @@ scalacOptions ++= Seq(
 Compile / compile / scalacOptions ++= Seq(
   // generate errors on procedure syntax
   "-Wconf:cat=deprecation:e",
+  // suppress the warning that is coming from IgnoreWarning
+  "-Wconf:src=scala/IgnoreWarning.scala:s",
   "-Xfuture",
   "-deprecation"
 )

--- a/src/sbt-test/sbt-scalafix/relax-scalacOptions/src/main/scala/IgnoreWarning.scala
+++ b/src/sbt-test/sbt-scalafix/relax-scalacOptions/src/main/scala/IgnoreWarning.scala
@@ -1,0 +1,3 @@
+object IgnoreWarning {
+  def get[T](o: Option[T]): T = o match { case Some(t) => t }
+}


### PR DESCRIPTION
Creating this to start a conversation about it and to see if this would be alright as a follow-up to some of the work done in https://github.com/scalacenter/sbt-scalafix/pull/196. If I understood the conversation right you want to avoid situations where this is set to error out causing issues. However, currently it strips out any usage of `-Wconf`. The situation that I'm in is that we want to avoid warnings from generated sources since we generate a _ton_ of files with scalaxb that contains a whole bunch of compiler warnings.  To silence these we use `-Wconf:src=src_managed/.*:silent`. This works great during normal compilation, but then when we run scalafix check in our CI our logs end up being full or warnings causing a scare. Would it be possible to make this more fine-grained like this to specifically target `:e` or `:error`?