### PR TITLE
don't force sonatypeSnapshots on all ScalafixTestkitPlugin users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,9 @@ libraryDependencies ++= List(
 scalaVersion := "2.12.15"
 
 // keep this as low as possible to avoid running into binary incompatibility such as https://github.com/sbt/sbt/issues/5049
+// check if following hacks can be removed upon bumping:
+// - SemanticdbPlugin
+// - includePluginResolvers
 pluginCrossBuild / sbtVersion := "1.2.1"
 
 scriptedSbt := {

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,18 @@ plugin, refer to the
 Please report issues to the main scalafix repository:
 https://github.com/scalacenter/scalafix/issues
 
+## Nightlies
+
+Our CI publishes a [snapshot release to Sonatype](https://oss.sonatype.org/content/repositories/snapshots/ch/epfl/scala/sbt-scalafix_2.12_1.0/)
+on every merge into main. The latest snapshot at the time of the writing can be used via:
+
+```diff
+  // project/plugins.sbt
+-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
++addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34+5-5dfe5fb6-SNAPSHOT")
++resolvers += Resolver.sonatypeRepo("snapshots")
+ ```
+
 ## Team
 
 The current maintainers (people who can merge pull requests) are:

--- a/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
@@ -37,14 +37,15 @@ object ScalafixTestkitPlugin extends AutoPlugin {
   override def buildSettings: Seq[Def.Setting[_]] =
     List(
       // This makes it simpler to use sbt-scalafix SNAPSHOTS: such snapshots may bring scalafix-* SNAPSHOTS which is fine in the
-      // meta build as the same resolver (declared in project/plugins.sbt) is used. However, since it is advised in the docs and the g8
-      // template to build testkit-enabled projects against scalafix-testkit:_root_.scalafix.sbt.BuildInfo.scalafixVersion, the same
-      // resolver is needed here as well.
+      // meta build as the same resolver (declared in project/plugins.sbt) is used. However, since testkit-enabled projects are
+      // built against a version of scalafix-testkit dictated by scalafix.sbt.BuildInfo.scalafixVersion, the same resolver is
+      // needed here as well.
       includePluginResolvers := true
     )
 
   override def projectSettings: Seq[Def.Setting[_]] =
     List(
+      libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % BuildInfo.scalafixVersion % Test cross CrossVersion.full,
       scalafixTestkitInputScalacOptions := scalacOptions.value,
       scalafixTestkitInputScalaVersion := scalaVersion.value,
       Test / resourceGenerators += Def.task {

--- a/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
@@ -28,9 +28,19 @@ object ScalafixTestkitPlugin extends AutoPlugin {
   }
   import autoImport._
 
+  // Since we currently build against sbt 1.2.1 and https://github.com/sbt/sbt/blob/6664cbe/main/src/main/scala/sbt/Keys.scala#L414
+  // was introduced in sbt 1.3.1, we redefine that setting key to assign it, with the gotcha that it only has an effect if the
+  // client uses sbt 1.3.1 or later.
+  private val includePluginResolvers =
+    settingKey[Boolean]("Include the resolvers from the metabuild.")
+
   override def buildSettings: Seq[Def.Setting[_]] =
     List(
-      resolvers += Resolver.sonatypeRepo("snapshots")
+      // This makes it simpler to use sbt-scalafix SNAPSHOTS: such snapshots may bring scalafix-* SNAPSHOTS which is fine in the
+      // meta build as the same resolver (declared in project/plugins.sbt) is used. However, since it is advised in the docs and the g8
+      // template to build testkit-enabled projects against scalafix-testkit:_root_.scalafix.sbt.BuildInfo.scalafixVersion, the same
+      // resolver is needed here as well.
+      includePluginResolvers := true
     )
 
   override def projectSettings: Seq[Def.Setting[_]] =


### PR DESCRIPTION
- Fixes https://github.com/scalacenter/scalafix/issues/1535 (first commit)
- Document in second commit what https://github.com/scalacenter/sbt-scalafix/pull/211 was already about
- Convenience addition in third commit, allowing
  - https://github.com/scalacenter/scalafix/pull/1537 
  - https://github.com/scalacenter/scalafix.g8/pull/68