### PR TITLE
support and favor ammonite/coursier syntax for dependency:

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/DependencyRule.scala
+++ b/src/main/scala/scalafix/internal/sbt/DependencyRule.scala
@@ -9,8 +9,13 @@ case class DependencyRule(
 )
 
 object DependencyRule {
-  lazy val Parsed: Regex =
+  lazy val Deprecated: Regex =
     "dependency:(.+)@(.+):(.+):(.+)".r
-  def format: String =
+  def deprecatedFormat: String =
     "dependency:$RULE_NAME@$ORGANIZATION:$ARTIFACT_NAME:$VERSION"
+
+  lazy val Parsed: Regex =
+    "dependency:(.+)@(.+)::(.+):(.+)".r
+  def format: String =
+    "dependency:$RULE_NAME@$ORGANIZATION::$ARTIFACT_NAME:$VERSION"
 }

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -256,6 +256,11 @@ object ScalafixPlugin extends AutoPlugin {
     val parsed = dependencyRules.map {
       case DependencyRule.Parsed(ruleName, org, art, ver) =>
         DependencyRule(ruleName, org %% art % ver)
+      case DependencyRule.Deprecated(ruleName, org, art, ver) =>
+        stdoutLogger.warn(
+          s"${DependencyRule.deprecatedFormat} is deprecated, please use ${DependencyRule.format} instead"
+        )
+        DependencyRule(ruleName, org %% art % ver)
       case els =>
         stdoutLogger.error(
           s"""|Invalid rule:    $els

--- a/src/sbt-test/sbt-scalafix/dependency/build.sbt
+++ b/src/sbt-test/sbt-scalafix/dependency/build.sbt
@@ -1,6 +1,9 @@
 scalaVersion := "2.12.7"
 
 TaskKey[Unit]("check") := {
-  val text = IO.read((Compile / sourceDirectory).value / "scala" / "A.scala")
-  assert(text.contains("// v1 SemanticRule!"), text)
+  val a = IO.read((Compile / sourceDirectory).value / "scala" / "A.scala")
+  assert(a.contains("// v1 SemanticRule!"), a)
+
+  val b = IO.read((Test / sourceDirectory).value / "scala" / "B.scala")
+  assert(b.contains("// v1 SemanticRule!"), b)
 }

--- a/src/sbt-test/sbt-scalafix/dependency/src/test/scala/B.scala
+++ b/src/sbt-test/sbt-scalafix/dependency/src/test/scala/B.scala
@@ -1,0 +1,1 @@
+object B

--- a/src/sbt-test/sbt-scalafix/dependency/test
+++ b/src/sbt-test/sbt-scalafix/dependency/test
@@ -1,3 +1,4 @@
 > scalafixEnable
-> scalafix dependency:SemanticRule@ch.epfl.scala:example-scalafix-rule:1.4.0
+> scalafix dependency:SemanticRule@ch.epfl.scala::example-scalafix-rule:1.4.0
+> Test / scalafix dependency:SemanticRule@ch.epfl.scala:example-scalafix-rule:1.4.0
 > check


### PR DESCRIPTION
Rationale: the `::` syntax is now standard in scala tooling to designate scala artifacts

Docs companion: https://github.com/scalacenter/scalafix/pull/1542