### PR TITLE
make scalafixEnable less aggressive & more future-proof

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/Implicits.scala
+++ b/src/main/scala/scalafix/internal/sbt/Implicits.scala
@@ -1,0 +1,25 @@
+package scalafix.internal.sbt
+
+import sbt.librarymanagement._
+import scalafix.sbt.InvalidArgument
+
+trait Implicits {
+  implicit class XtensionModuleID(m: ModuleID) {
+    def asCoursierCoordinates: String = {
+      m.crossVersion match {
+        case _: Disabled =>
+          s"${m.organization}:${m.name}:${m.revision}"
+        case _: CrossVersion.Binary =>
+          s"${m.organization}::${m.name}:${m.revision}"
+        case _: CrossVersion.Full =>
+          s"${m.organization}:::${m.name}:${m.revision}"
+        case other =>
+          throw new InvalidArgument(
+            s"Unsupported crossVersion $other for dependency $m"
+          )
+      }
+    }
+  }
+}
+
+object Implicits extends Implicits

--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -22,29 +22,15 @@ object Arg {
       repositories: Seq[Repository]
   ) extends Arg
       with CacheKey {
+
+    import scalafix.internal.sbt.Implicits._
+
     override def apply(sa: ScalafixArguments): ScalafixArguments =
       sa.withToolClasspath(
         customURIs.map(_.toURL).asJava,
         customDependencies.map(_.asCoursierCoordinates).asJava,
         repositories.asJava
       )
-
-    private implicit class XtensionModuleID(m: ModuleID) {
-      def asCoursierCoordinates: String = {
-        m.crossVersion match {
-          case _: Disabled =>
-            s"${m.organization}:${m.name}:${m.revision}"
-          case _: CrossVersion.Binary =>
-            s"${m.organization}::${m.name}:${m.revision}"
-          case _: CrossVersion.Full =>
-            s"${m.organization}:::${m.name}:${m.revision}"
-          case other =>
-            throw new InvalidArgument(
-              s"Unsupported crossVersion $other for dependency $m"
-            )
-        }
-      }
-    }
   }
 
   case class Rules(rules: Seq[String]) extends Arg with CacheKey {

--- a/src/main/scala/scalafix/sbt/ScalafixEnable.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixEnable.scala
@@ -2,66 +2,161 @@ package scalafix.sbt
 
 import sbt._
 import sbt.Keys._
+import sbt.VersionNumber.SemVer
+
+import ScalafixPlugin.autoImport.scalafixResolvers
+
+import collection.JavaConverters._
+import scala.util._
+import coursierapi.Repository
 
 /** Command to automatically enable semanticdb compiler output for shell session
   */
 object ScalafixEnable {
 
-  /** If the provided Scala binary version is supported, return the full version
-    * required for running semanticdb-scalac.
+  /** If the provided Scala binary version is supported, return the latest scala
+    * full version for which the recommended semanticdb-scalac is available
     */
-  private lazy val semanticdbScalacFullScalaVersion
-      : PartialFunction[(Long, Long), String] = (for {
+  private lazy val recommendedSemanticdbScalacScalaVersion
+      : PartialFunction[(Long, Long), VersionNumber] = (for {
     v <- BuildInfo.supportedScalaVersions
     p <- CrossVersion.partialVersion(v).toList
-  } yield p -> v).toMap
+  } yield p -> VersionNumber(v)).toMap
 
-  /** If the provided Scala binary version is supported, return the full version
-    * required for running semanticdb-scalac or None if support is built-in in
-    * the compiler and the full version does not need to be adjusted.
+  /** If the provided Scala binary version is supported, return the latest scala
+    * full version for which the recommended semanticdb-scalac is available, or
+    * None if semanticdb support is built-in in the compiler
     */
-  private lazy val maybeSemanticdbScalacFullScalaVersion
-      : PartialFunction[(Long, Long), Option[String]] =
-    semanticdbScalacFullScalaVersion.andThen(Some.apply).orElse {
+  private lazy val maybeRecommendedSemanticdbScalacScalaVersion
+      : PartialFunction[(Long, Long), Option[VersionNumber]] =
+    recommendedSemanticdbScalacScalaVersion.andThen(Some.apply).orElse {
       // semanticdb is built-in in the Scala 3 compiler
       case (major, _) if major == 3 => None
     }
 
-  /** Collect projects across the entire build, using the partial function
-    * accepting a Scala binary version
-    */
-  private def collectProjects[U](
-      extracted: Extracted,
-      pf: PartialFunction[(Long, Long), U]
-  ): Seq[(ProjectRef, U)] = for {
-    p <- extracted.structure.allProjectRefs
-    version <- (p / scalaVersion).get(extracted.structure.data).toList
-    partialVersion <- CrossVersion.partialVersion(version).toList
-    res <- pf.lift(partialVersion).toList
-  } yield p -> res
+  /** Collect compatible projects across the entire build */
+  private def collectProjects(extracted: Extracted): Seq[CompatibleProject] =
+    for {
+      p <- extracted.structure.allProjectRefs
+      scalaV <- (p / scalaVersion).get(extracted.structure.data).toList
+      partialVersion <- CrossVersion.partialVersion(scalaV).toList
+      maybeRecommendedSemanticdbScalacV <-
+        maybeRecommendedSemanticdbScalacScalaVersion.lift(partialVersion).toList
+      scalafixResolvers0 <- (p / scalafixResolvers)
+        .get(extracted.structure.data)
+        .toList
+      semanticdbCompilerPlugin0 <- (p / semanticdbCompilerPlugin)
+        .get(extracted.structure.data)
+        .toList
+    } yield CompatibleProject(
+      p,
+      VersionNumber(scalaV),
+      semanticdbCompilerPlugin0,
+      scalafixResolvers0,
+      maybeRecommendedSemanticdbScalacV
+    )
+
+  private case class CompatibleProject(
+      ref: ProjectRef,
+      scalaVersion0: VersionNumber,
+      semanticdbCompilerPlugin0: ModuleID,
+      scalafixResolvers0: Seq[Repository],
+      maybeRecommendedSemanticdbScalacScalaV: Option[VersionNumber]
+  )
 
   lazy val command = Command.command(
     "scalafixEnable",
-    briefHelp = "Configure SemanticdbPlugin for scalafix.",
-    detail = """1. set semanticdbEnabled & semanticdbVersion
-      |2. conditionally sets scalaVersion when support is not built-in in the compiler""".stripMargin
+    briefHelp =
+      "Configure SemanticdbPlugin for scalafix on supported projects.",
+    detail = """1. set semanticdbEnabled := true
+      |2. for scala 2.x,
+      |  - set semanticdbCompilerPlugin to the scalameta version tracked by scalafix if available for scalaVersion, 
+      |  - otherwise set semanticdbCompilerPlugin to the earliest compatible version available for scalaVersion,
+      |  - otherwise force scalaVersion to the latest version supported by the scalameta version tracked by scalafix.""".stripMargin
   ) { s =>
     val extracted = Project.extract(s)
     val scalacOptionsSettings = Seq(Compile, Test).flatMap(
       inConfig(_)(ScalafixPlugin.relaxScalacOptionsConfigSettings)
     )
     val settings = for {
-      (p, maybeFullVersion) <- collectProjects(
-        extracted,
-        maybeSemanticdbScalacFullScalaVersion
-      )
-      enableSemanticdbPlugin <- maybeFullVersion.toList.map { fullVersion =>
-        scalaVersion := fullVersion,
-      } :+ (semanticdbEnabled := true)
+      project <- collectProjects(extracted)
+      enableSemanticdbPlugin <-
+        project.maybeRecommendedSemanticdbScalacScalaV.toList
+          .flatMap { recommendedSemanticdbScalacScalaV =>
+
+            import scalafix.internal.sbt.Implicits._
+            val semanticdbScalacModule =
+              coursierapi.Dependency
+                .parse(
+                  project.semanticdbCompilerPlugin0.asCoursierCoordinates,
+                  coursierapi.ScalaVersion.of(project.scalaVersion0.toString)
+                )
+                .getModule
+            val recommendedSemanticdbV =
+              VersionNumber(BuildInfo.scalametaVersion)
+            val compatibleSemanticdbVs = Try(
+              coursierapi.Versions.create
+                .withRepositories(project.scalafixResolvers0: _*)
+                .withModule(semanticdbScalacModule)
+                .versions()
+                .getMergedListings
+                .getAvailable
+                .asScala
+                .map(VersionNumber.apply)
+                // don't use snapshots
+                .filter(_.extras == Nil)
+                // https://github.com/scalameta/scalameta/blob/main/COMPATIBILITY.md
+                .filter(SemVer.isCompatible(_, recommendedSemanticdbV))
+                .toList
+            )
+
+            compatibleSemanticdbVs match {
+              case Success(Nil) | Failure(_) =>
+                Seq(
+                  scalaVersion := {
+                    val v = recommendedSemanticdbScalacScalaV.toString
+                    sLog.value.warn(
+                      s"Forcing scalaVersion $v in project " +
+                        s"${project.ref.project} since no semanticdb-scalac " +
+                        s"version binary-compatible with $recommendedSemanticdbV " +
+                        s"and cross-published for scala " +
+                        s"${project.scalaVersion0.toString} was found - " +
+                        s"consider bumping scala"
+                    )
+                    v
+                  },
+                  semanticdbCompilerPlugin :=
+                    semanticdbCompilerPlugin.value
+                      .withRevision(recommendedSemanticdbV.toString)
+                )
+              case Success(available)
+                  if available.contains(recommendedSemanticdbV) =>
+                Seq(
+                  semanticdbCompilerPlugin :=
+                    semanticdbCompilerPlugin.value
+                      .withRevision(recommendedSemanticdbV.toString)
+                )
+              case Success(earliestAvailable :: _) =>
+                Seq(
+                  semanticdbCompilerPlugin := {
+                    val v = earliestAvailable.toString
+                    sLog.value.info(
+                      s"Using semanticdb-scalac $v in project " +
+                        s"${project.ref.project} since the version " +
+                        s"${recommendedSemanticdbV} tracked by scalafix " +
+                        s"${BuildInfo.scalafixVersion} is not available for " +
+                        s"scala ${project.scalaVersion0.toString} - " +
+                        s"consider upgrading sbt-scalafix or bumping scala"
+                    )
+                    semanticdbCompilerPlugin.value.withRevision(v)
+                  }
+                )
+            }
+          } :+ (semanticdbEnabled := true)
       settings <-
-        inScope(ThisScope.copy(project = Select(p)))(
+        inScope(ThisScope.copy(project = Select(project.ref)))(
           scalacOptionsSettings ++ enableSemanticdbPlugin
-        ) :+ (Global / semanticdbVersion := BuildInfo.scalametaVersion)
+        )
     } yield settings
     extracted.appendWithoutSession(settings, s)
   }

--- a/src/sbt-test/sbt-scalafix/dependency/build.sbt
+++ b/src/sbt-test/sbt-scalafix/dependency/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.12"
+scalaVersion := "2.12.7"
 
 TaskKey[Unit]("check") := {
   val a = IO.read((Compile / sourceDirectory).value / "scala" / "A.scala")

--- a/src/sbt-test/sbt-scalafix/dependency/build.sbt
+++ b/src/sbt-test/sbt-scalafix/dependency/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.12"
 
 TaskKey[Unit]("check") := {
   val a = IO.read((Compile / sourceDirectory).value / "scala" / "A.scala")

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
@@ -15,7 +15,7 @@ lazy val scala211_old = project.settings(
 
 // 2.11.x is supported
 lazy val scala211 = project.settings(
-  // semanticdb-scalac_2.11.11 no longer available, became available as of 2.0.0
+  // semanticdb-scalac_2.11.11 no longer available after 4.1.9
   scalaVersion := "2.11.11"
 )
 
@@ -46,7 +46,7 @@ TaskKey[Unit]("check") := {
 
   assert((scala211 / semanticdbEnabled).value == true)
   assert((scala211 / scalaVersion).value == "2.11.11")
-  assert((scala211 / semanticdbCompilerPlugin).value.revision == "4.1.0")
+  assert((scala211 / semanticdbCompilerPlugin).value.revision == "4.1.9")
   assert(
     (scala211 / Compile / compile / scalacOptions).value
       .count(_ == "-Yrangepos") == 1

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
@@ -1,54 +1,68 @@
 val V = _root_.scalafix.sbt.BuildInfo
 
-// 2.10 is not supported, scalafix is not enabled
+// 2.10 is not supported
 lazy val scala210 = project.settings(
   scalaVersion := "2.10.4",
   libraryDependencies := Nil,
   scalacOptions := Nil
 )
 
-// 2.12.0 is supported but the version is overidden
-lazy val overridesSettings = project.settings(
-  scalaVersion := "2.12.0",
-  libraryDependencies := Nil,
-  scalacOptions := Nil
+// 2.11.x is supported
+lazy val scala211_old = project.settings(
+  // semanticdb-scalac_2.11.0 was never available
+  scalaVersion := "2.11.0"
 )
 
 // 2.11.x is supported
 lazy val scala211 = project.settings(
-  scalaVersion := V.scala211
+  // semanticdb-scalac_2.11.11 no longer available, became available as of 2.0.0
+  scalaVersion := "2.11.11"
 )
 
 // 2.12.x is supported
 lazy val scala212 = project.settings(
-  scalaVersion := V.scala212
+  // semanticdb-scalac_2.12.15 not yet available in 4.4.10, became available as of 4.4.28
+  scalaVersion := "2.12.15"
 )
 
 // 2.13.x is supported
 lazy val scala213 = project.settings(
-  scalaVersion := V.scala213
+  // semanticdb-scalac_2.13.4 available in 4.4.10, became available as of 4.4.0
+  scalaVersion := "2.13.4"
 )
 
 TaskKey[Unit]("check") := {
-  // nothing should change for the 2.10 project
+  assert((scala210 / semanticdbEnabled).value == false)
   assert((scala210 / scalaVersion).value == "2.10.4")
   assert((scala210 / Compile / compile / scalacOptions).value.isEmpty)
 
-  // 2.12.0 should be overidden to 2.12.X
-  assert((overridesSettings / scalaVersion).value == V.scala212)
+  assert((scala211_old / semanticdbEnabled).value == true)
+  assert((scala211_old / scalaVersion).value == "2.11.12")
+  assert((scala211_old / semanticdbCompilerPlugin).value.revision == "4.4.10")
   assert(
-    (overridesSettings / Compile / compile / scalacOptions).value
-      .contains("-Yrangepos")
+    (scala211_old / Compile / compile / scalacOptions).value
+      .count(_ == "-Yrangepos") == 1
   )
 
+  assert((scala211 / semanticdbEnabled).value == true)
+  assert((scala211 / scalaVersion).value == "2.11.11")
+  assert((scala211 / semanticdbCompilerPlugin).value.revision == "4.1.0")
   assert(
     (scala211 / Compile / compile / scalacOptions).value
       .count(_ == "-Yrangepos") == 1
   )
+
+  assert((scala212 / semanticdbEnabled).value == true)
+  assert((scala212 / scalaVersion).value == "2.12.15")
+  assert((scala212 / semanticdbCompilerPlugin).value.revision == "4.4.28")
   assert(
     (scala212 / Compile / compile / scalacOptions).value
       .count(_ == "-Yrangepos") == 1
   )
+
+  assert((scala213 / semanticdbEnabled).value == true)
+  assert((scala213 / scalaVersion).value == "2.13.4")
+  assert((scala213 / semanticdbCompilerPlugin).value.revision == "4.4.10")
   assert(
     (scala213 / Test / compile / scalacOptions).value
       .count(_ == "-Yrangepos") == 1

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/project/plugins.sbt
@@ -1,2 +1,5 @@
 resolvers += Resolver.sonatypeRepo("public")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))
+
+// https://github.com/scalameta/scalameta/blob/v4.4.10/project/Versions.scala
+dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "0.9.27" // scala-steward:off


### PR DESCRIPTION
1. Keep the build scala version when semanticdb-scalac is available for that scala version for the scalameta version that scalafix tracks.
1. If not, try to find the earliest binany-compatible semanticdb-scalac (preferred over the latest last to be more repeatable) and use it instead.
1. Only when that fails (or resolution fails), force the scala version as previously.

(1) avoids unnecessary scala bumps which can result in
- zinc cache invalidation
- compilation failures because of stricter compiler checks
- resolution failures because of yet-unpublished compiler plugins (fixes https://github.com/scalacenter/scalafix/issues/1573)

(2) opens the possibility for using sbt-scalafix on scala versions released "in the future" without any scalameta/scalafix bump (as long as scalameta is published obviously).

---

```
sbt:sbt-scalafix> scripted sbt-scalafix/scalafixEnable
...
[warn] Forcing scalaVersion 2.11.12 in project scala211_old since no semanticdb-scalac version binary-compatible with 4.4.10 and cross-published for scala 2.11.0 was found - consider bumping scala
[info] Using semanticdb-scalac 4.1.0 in project scala211 since the version 4.4.10 tracked by scalafix 0.9.27 is not available for scala 2.11.11 - consider upgrading sbt-scalafix or bumping scala
[info] Using semanticdb-scalac 4.4.28 in project scala212 since the version 4.4.10 tracked by scalafix 0.9.27 is not available for scala 2.12.15 - consider upgrading sbt-scalafix or bumping scala
```