### PR TITLE
wire scalafix initialization logs to proper logger

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -9,6 +9,7 @@ import scalafix.sbt.InvalidArgument
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
+import java.io.PrintStream
 
 sealed trait Arg extends (ScalafixArguments => ScalafixArguments)
 
@@ -133,8 +134,16 @@ object ScalafixInterface {
         )
         .newArguments()
         .withMainCallback(callback)
+      val printStream =
+        new PrintStream(
+          LoggingOutputStream(
+            logger,
+            Level.Info
+          )
+        )
       new ScalafixInterface(scalafixArguments, Nil)
         .withArgs(
+          Arg.PrintStream(printStream),
           Arg.ToolClasspath(
             Nil,
             scalafixDependencies,


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1565/files#r825365856

```diff
 sbt> scalafix dependency:SemanticRule@ch.epfl.scala::example-scalafix-rule:1.4.0
-Loading external rule(s) built against an old version of scalafix (0.9.16).
-This might not be a problem, but if you run into unexpected behavior, you should either:
-1. downgrade scalafix to 0.9.16
-2. try a more recent version of the rules(s) if available; request the rule maintainer
-   to build against scalafix 0.10.0 or later if that does not help
+[info] Loading external rule(s) built against an old version of scalafix (0.9.16).
+[info] This might not be a problem, but if you run into unexpected behavior, you should either:
+[info] 1. downgrade scalafix to 0.9.16
+[info] 2. try a more recent version of the rules(s) if available; request the rule maintainer
+[info]    to build against scalafix 0.10.0 or later if that does not help
 ...
