### PR TITLE
scalafixEnable: preserve versions set by ++

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixEnable.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixEnable.scala
@@ -184,6 +184,6 @@ object ScalafixEnable {
           scalacOptionsSettings ++ enableSemanticdbPlugin
         )
     } yield settings
-    extracted.appendWithoutSession(settings, s)
+    extracted.appendWithSession(settings, s)
   }
 }

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/build.sbt
@@ -28,7 +28,8 @@ lazy val scala212 = project.settings(
 // 2.13.x is supported
 lazy val scala213 = project.settings(
   // semanticdb-scalac_2.13.4 available in 4.4.10, became available as of 4.4.0
-  scalaVersion := "2.13.4"
+  scalaVersion := "2.13.4",
+  crossScalaVersions := Seq("2.12.15")
 )
 
 TaskKey[Unit]("check") := {
@@ -67,4 +68,8 @@ TaskKey[Unit]("check") := {
     (scala213 / Test / compile / scalacOptions).value
       .count(_ == "-Yrangepos") == 1
   )
+}
+
+TaskKey[Unit]("checkVersion") := {
+  assert((scala213 / scalaVersion).value == "2.12.15")
 }

--- a/src/sbt-test/sbt-scalafix/scalafixEnable/test
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/test
@@ -5,3 +5,9 @@
 -> scala212/test:compile
 > scala212/scalafixAll RemoveUnused
 > scala212/test:compile
+
+-> checkVersion
+> ++2.12.15 -v
+> checkVersion
+> scalafixEnable
+> checkVersion


### PR DESCRIPTION
Regression of https://github.com/scalacenter/sbt-scalafix/pull/292
Found via https://github.com/scalameta/munit/pull/513
Addresses a special case of https://github.com/scalacenter/scalafix/issues/986 (https://github.com/sbt/sbt/issues/5459 does not seem to apply after `++`)