### PR TITLE
don't force slf4j 2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,6 @@ object Dependencies {
   val all = List(
     "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.1.202206130422-r",
     "ch.epfl.scala" % "scalafix-interfaces" % scalafixVersion,
-    "io.get-coursier" % "interface" % "1.0.12"
+    "io.get-coursier" % "interface" % "1.0.9"
   )
 }


### PR DESCRIPTION
Effectively revert https://github.com/coursier/interface/commit/03ce01c612665ed7d2d7ffe0ad32395b39d5e099, to avoid problem highlighted by https://github.com/scalacenter/scalafix/pull/1718#issuecomment-1369225217 