### PR TITLE
overriden scalacOptions are not supported by scalafixEnable

### DIFF
--- a/src/sbt-test/sbt-scalafix/scalafixEnable/project/FatalWarningsPlugin.scala
+++ b/src/sbt-test/sbt-scalafix/scalafixEnable/project/FatalWarningsPlugin.scala
@@ -12,15 +12,9 @@ object FatalWarningsPlugin extends AutoPlugin {
   override def requires: Plugins = ScalafixPlugin
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    Test / compile / scalacOptions := {
-      val old = (Test / compile / scalacOptions).value
-      val strict = Seq(
-        "-Xfatal-warnings",
-        "-Ywarn-unused"
-      )
-      // For sbt 1.3+ where SemanticdbPlugin is available and preferred to manual tweaking,
-      // scalafixEnable does not manage to enable Semanticdb when scalacOptions are overriden
-      if (sbtVersion.value.split("\\.")(1).toInt >= 3) old ++ strict else strict
-    }
+    Test / compile / scalacOptions ++= Seq(
+      "-Xfatal-warnings",
+      "-Ywarn-unused"
+    )
   )
 }


### PR DESCRIPTION
https://github.com/scalacenter/sbt-scalafix/commit/30d8d4d950a2e8741d7c89d87d7bb3a4b7b604b1#diff-99217f6aaf66894a50a0dfb21ae350532d758c711dbcbd670ae6249bc965317a already documented that [the feature](https://github.com/scalacenter/sbt-scalafix/pull/203) was not working with sbt 1.3.x and later, so [now that earlier versions are no longer tested/supported](https://github.com/scalacenter/sbt-scalafix/pull/291), we should kill the dead branch of the test.