### PR TITLE
fix test relying on ScalaTest 3.0.x

### DIFF
--- a/src/sbt-test/sbt-1.5/testkit/tests/src/test/scala/fix/InputOutputSuite.scala
+++ b/src/sbt-test/sbt-1.5/testkit/tests/src/test/scala/fix/InputOutputSuite.scala
@@ -2,13 +2,13 @@ package fix
 
 import scalafix.testkit._
 import scala.util.control.NonFatal
-import org.scalatest.FunSuiteLike
+import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.exceptions.TestFailedException
 
 object IntputOutputSuite {
   def main(args: Array[String]): Unit = {
     if (Array("--save-expect").sameElements(args)) {
-      val suite = new AbstractSemanticRuleSuite with FunSuiteLike {
+      val suite = new AbstractSemanticRuleSuite with AnyFunSuiteLike {
         override val props = TestkitProperties.loadFromResources()
         override val isSaveExpect = true
 
@@ -30,6 +30,6 @@ object IntputOutputSuite {
   }
 }
 
-class IntputOutputSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
+class IntputOutputSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
   runAllTests()
 }


### PR DESCRIPTION
Fix "expected" failure introduced after rushing https://github.com/scalacenter/sbt-scalafix/pull/348 out for the 0.11.0 release, caused by https://github.com/scalacenter/scalafix/pull/1750.

