### PR TITLE
better error reporting when semanticdb-scalac is not found

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val x = List(1) // scalafix:ok
-  def scalafixVersion: String = "0.11.0+118-1b88e1f8-SNAPSHOT"
+  def scalafixVersion: String = "0.11.0+132-89b843d2-SNAPSHOT"
 
   val all = List(
     "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.2.202306221912-r",

--- a/src/sbt-test/sbt-1.5/testkit/build.sbt
+++ b/src/sbt-test/sbt-1.5/testkit/build.sbt
@@ -5,6 +5,7 @@ lazy val scala3Version = "3.0.0"
 
 inThisBuild(
   List(
+    scalaVersion := V.scala212, // don't let tests project fall back to sbt's old default
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     // need for sbt <1.7.0 as includePluginResolvers has no effect, see https://github.com/sbt/sbt/pull/6853

--- a/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion := "2.12.14",
+    scalaVersion := "2.12.18",
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % "4.3.10" % Test,
       "org.scalameta" %% "munit" % "0.7.9" % Test,

--- a/src/sbt-test/sbt-scalafix/inconfig/build.sbt
+++ b/src/sbt-test/sbt-scalafix/inconfig/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion := "2.12.14",
+    scalaVersion := "2.12.18",
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % "4.3.10" % Test,
       "org.scalameta" %% "munit" % "0.7.9" % Test,

--- a/src/sbt-test/sbt-scalafix/root-validation/build.sbt
+++ b/src/sbt-test/sbt-scalafix/root-validation/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion := "2.12.14"
+    scalaVersion := "2.12.18"
   )
 )
 

--- a/src/sbt-test/sbt-scalafix/semanticdb-enabled/build.sbt
+++ b/src/sbt-test/sbt-scalafix/semanticdb-enabled/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion := "2.12.14",
+    scalaVersion := "2.12.18",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision
   )

--- a/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/build.sbt
+++ b/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/build.sbt
@@ -1,0 +1,22 @@
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalaVersion := "2.13.7" // last semanticdb-scalac published for that scala version is 4.8.4
+  )
+)
+
+lazy val checkLogs =
+  taskKey[Unit]("Check presence of call to action in update logs")
+
+checkLogs := {
+  val taskStreams = (update / streams).value
+  val reader = taskStreams.readText(taskStreams.key)
+  val logLines = Stream
+    .continually(reader.readLine())
+    .takeWhile(_ != null)
+    .force
+  assert(
+    logLines.exists(_.contains("Please upgrade to a more recent Scala patch version or uninstall sbt-scalafix"))
+  )
+}

--- a/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/project/plugins.sbt
+++ b/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("public")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/test
+++ b/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/test
@@ -1,0 +1,2 @@
+-> scalafix
+> checkLogs

--- a/src/sbt-test/skip-java17/scalafixResolvers/build.sbt
+++ b/src/sbt-test/skip-java17/scalafixResolvers/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.18"
 
 TaskKey[Unit]("check") := {
   val expectedRepositories: Seq[String] = Seq(


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1857

### Lead-up

Since https://github.com/scalameta/scalameta/pull/3250, [semanticdb-scalac](https://mvnrepository.com/artifact/org.scalameta/semanticdb-scalac) is no longer published for all patch releases of Scala 2.13 and most patch releases of Scala 2.12, but only the 4 latest for each.

### Impact

`scalafixEnable` is able to lookup a suitable scalameta version as of https://github.com/scalacenter/sbt-scalafix/pull/292, but "permanent" sbt-scalafix / Scala 2.x users, leveraging sbt's SemanticdbPlugin via
```diff
+    semanticdbEnabled := true, // enable SemanticDB
+    semanticdbVersion := scalafixSemanticdb.revision // only required for Scala 2.x
```
[per the documentation](https://github.com/scalacenter/scalafix/blob/f4dcc6fa889c4a03f71881b3b6ac962bde59c2ef/docs/users/installation.md?plain=1#L82-L113), are at the risk of getting errors if they run an old patch scala version, while it was working fine until now (up to Scalafix 0.11.0 / scalameta 4.7.8).

That means that this effectively a breaking change, but as the likelihood of a user setting up the latest scalafix version against a project that is running a very outdated scala version is minimal, this PR simply improves error reporting and we won't be bumping the minor version to highlight the change.