### PR TITLE
document weird behavior

### DIFF
--- a/src/sbt-test/sbt-scalafix/explicit-files/test
+++ b/src/sbt-test/sbt-scalafix/explicit-files/test
@@ -22,6 +22,18 @@
 > scalafix -f=src/main/scala/OK.scala
 
 
+# QUESTIONNABLE USAGES
+# --------------------
+
+# Targeting valid files from an aggregated project succeeds:
+# only the project for which the `--files` value is valid runs the invocation
+> scalafix -f=ok_and_ko/src/main/scala/OK.scala
+
+# Targeting valid files both from an aggregating project and from one of its aggregated project fails:
+# no project can validate both `--files` value, so the aggregating project shows the failure
+-> scalafix -f=ok_and_ko/src/main/scala/OK.scala -f=src/main/scala/OK.scala
+
+
 # INCORRECT USAGES
 # ----------------
 


### PR DESCRIPTION
Follows https://github.com/scalacenter/sbt-scalafix/pull/378 & https://github.com/scalacenter/scalafix/issues/1874

The sbt behavior or completions for aggregating tasks (typically `scalafix` on the root project) is interesting as all aggregated projects contribute to the possible completion values.
* everything goes well if at one (resp. several) aggregated project(s) can validate all the arguments, in which case that one runs (resp. these ones run) and the others are silently skipped
* if provided several arguments valid each of them in one different aggregated project, the invocation will fail, showing the validation error on the aggregating project.