### PR TITLE
old sbt versions can run on recent JDKs when loaded with scripted

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,17 +50,6 @@ scalaVersion := "2.12.19"
 // keep this as low as possible to avoid running into binary incompatibility such as https://github.com/sbt/sbt/issues/5049
 pluginCrossBuild / sbtVersion := "1.3.1"
 
-scriptedSbt := {
-  val jdk = System.getProperty("java.specification.version").toDouble
-
-  if (jdk >= 21)
-    "1.9.0" // first release that supports JDK21
-  else if (jdk >= 17)
-    "1.5.5" // first release that supports JDK17
-  else
-    "1.3.0"
-}
-
 libraryDependencies += compilerPlugin(scalafixSemanticdb)
 
 scalacOptions ++= List("-Ywarn-unused", "-Yrangepos")


### PR DESCRIPTION
It seems that https://github.com/scalacenter/sbt-scalafix/commit/a619fb7d02bef70116b85c65dc0c7ae9674cb8e8#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91 is no longer required (on recent sbt versions?)