### PR TITLE
add `scalafixJGitCompletion` key. reduce memory usage

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -14,7 +14,8 @@ class ScalafixCompletions(
     // depend on settings, while local rules classpath must be looked up via tasks
     loadedRules: () => Seq[ScalafixRule],
     terminalWidth: Option[Int],
-    allowedTargetFilesPrefixes: Seq[Path] // Nil means all values are valid
+    allowedTargetFilesPrefixes: Seq[Path], // Nil means all values are valid
+    jgitCompletion: JGitCompletion
 ) {
 
   private type P = Parser[String]
@@ -116,7 +117,6 @@ class ScalafixCompletions(
   private val namedRule2: Parser[ShellArgs.Rule] =
     namedRule.map(s => ShellArgs.Rule(s))
   private lazy val gitDiffParser: P = {
-    val jgitCompletion = new JGitCompletion(workingDirectory)
     token(
       NotQuoted,
       TokenCompletions.fixed((seen, _) => {

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -118,6 +118,13 @@ object ScalafixPlugin extends AutoPlugin {
 
   import autoImport._
 
+  private val scalafixJGitCompletion: SettingKey[JGitCompletion] =
+    SettingKey(
+      "scalafixJGitCompletion",
+      "Implementation detail - do not use",
+      Invisible
+    )
+
   private val scalafixDummyTask: TaskKey[Unit] =
     TaskKey(
       "scalafixDummyTask",
@@ -233,7 +240,10 @@ object ScalafixPlugin extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] =
     Seq(
-      scalafixScalaBinaryVersion := "2.12"
+      scalafixScalaBinaryVersion := "2.12",
+      scalafixJGitCompletion := new JGitCompletion(
+        (ThisBuild / baseDirectory).value.toPath
+      )
     )
 
   lazy val stdoutLogger = ConsoleLogger(System.out)
@@ -299,7 +309,8 @@ object ScalafixPlugin extends AutoPlugin {
         workingDirectory = (ThisBuild / baseDirectory).value.toPath,
         loadedRules = () => scalafixInterfaceProvider.value().availableRules(),
         terminalWidth = Some(JLineAccess.terminalWidth),
-        allowedTargetFilesPrefixes = Nil
+        allowedTargetFilesPrefixes = Nil,
+        jgitCompletion = (ThisBuild / scalafixJGitCompletion).value
       )
     )(_.parser)
     // workaround https://github.com/sbt/sbt/issues/3572 by invoking directly what Def.inputTaskDyn would via macro
@@ -352,7 +363,8 @@ object ScalafixPlugin extends AutoPlugin {
         loadedRules = () => scalafixInterfaceProvider.value().availableRules(),
         terminalWidth = Some(JLineAccess.terminalWidth),
         allowedTargetFilesPrefixes =
-          (scalafix / unmanagedSourceDirectories).value.map(_.toPath)
+          (scalafix / unmanagedSourceDirectories).value.map(_.toPath),
+        jgitCompletion = (ThisBuild / scalafixJGitCompletion).value
       )
     )(_.parser)
 

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -241,9 +241,7 @@ object ScalafixPlugin extends AutoPlugin {
   override def buildSettings: Seq[Def.Setting[_]] =
     Seq(
       scalafixScalaBinaryVersion := "2.12",
-      scalafixJGitCompletion := new JGitCompletion(
-        (ThisBuild / baseDirectory).value.toPath
-      )
+      scalafixJGitCompletion := new JGitCompletion(baseDirectory.value.toPath)
     )
 
   lazy val stdoutLogger = ConsoleLogger(System.out)
@@ -310,7 +308,7 @@ object ScalafixPlugin extends AutoPlugin {
         loadedRules = () => scalafixInterfaceProvider.value().availableRules(),
         terminalWidth = Some(JLineAccess.terminalWidth),
         allowedTargetFilesPrefixes = Nil,
-        jgitCompletion = (ThisBuild / scalafixJGitCompletion).value
+        jgitCompletion = scalafixJGitCompletion.value
       )
     )(_.parser)
     // workaround https://github.com/sbt/sbt/issues/3572 by invoking directly what Def.inputTaskDyn would via macro
@@ -364,7 +362,7 @@ object ScalafixPlugin extends AutoPlugin {
         terminalWidth = Some(JLineAccess.terminalWidth),
         allowedTargetFilesPrefixes =
           (scalafix / unmanagedSourceDirectories).value.map(_.toPath),
-        jgitCompletion = (ThisBuild / scalafixJGitCompletion).value
+        jgitCompletion = scalafixJGitCompletion.value
       )
     )(_.parser)
 

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -47,7 +47,8 @@ class SbtCompletionsSuite extends AnyFunSuite {
     workingDirectory = fs.workingDirectory.toAbsolutePath,
     loadedRules = () => loadedRules,
     terminalWidth = None,
-    allowedTargetFilesPrefixes = Seq(fs.workingDirectory.resolve("foo"))
+    allowedTargetFilesPrefixes = Seq(fs.workingDirectory.resolve("foo")),
+    jgitCompletion = new JGitCompletion(fs.workingDirectory.toAbsolutePath)
   ).parser
 
   def checkCompletion(name: String, testTags: Tag*)(
@@ -268,7 +269,8 @@ class SbtCompletionsSuite extends AnyFunSuite {
       workingDirectory = fs.workingDirectory.toAbsolutePath,
       loadedRules = () => Nil,
       terminalWidth = None,
-      allowedTargetFilesPrefixes = Nil
+      allowedTargetFilesPrefixes = Nil,
+      jgitCompletion = new JGitCompletion(fs.workingDirectory.toAbsolutePath)
     ).parser
   )("--test --files=foo", SkipWindows) { args =>
     assert(args == Left("""--files=foo


### PR DESCRIPTION
Maybe partially(?) fix https://github.com/scalacenter/scalafix/issues/1965 if there are many sub projects

if there is example sbt project as follow

```scala
lazy val p1 = project
lazy val p2 = project
lazy val p3 = project
lazy val p4 = project.disablePlugins(ScalafixPlugin)
```

### before

(`p1` + `p2` + `p3` + `implicit root project`) * ( `Compile/scalafix` + `Test/scalafix` + `scalafixAll` )
= 4 * 3
= 12`JGitCompletion` instances

### after

only one `JGitCompletion` instance