### PR TITLE
centralize ScalafixInterface memoization within a setting key

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
+++ b/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
@@ -2,21 +2,33 @@ package scalafix.internal.sbt
 
 import java.{util => ju}
 
+import scala.util.Try
+
 /** A basic thread-safe cache without any eviction. */
 class BlockingCache[K, V] {
 
   // Number of keys is expected to be very small so the global lock should not be a bottleneck
   private val underlying = ju.Collections.synchronizedMap(new ju.HashMap[K, V])
 
-  /** @param value
-    *   By-name parameter evaluated when the key if missing. Value computation
-    *   is guaranteed to be called only once per key across all invocations.
-    */
-  def getOrElseUpdate(key: K, value: => V): V =
-    underlying.computeIfAbsent(
-      key,
-      new ju.function.Function[K, V] {
-        override def apply(k: K): V = value
-      }
+  private case class SkipUpdate(prev: V) extends Exception
+
+  // Evaluations of `transform` are guaranteed to be sequential for the same key
+  def compute(key: K, transform: Option[V] => Option[V]): V = {
+    Try(
+      underlying.compute(
+        key,
+        new ju.function.BiFunction[K, V, V] {
+          override def apply(key: K, prev: V): V = {
+            transform(Option(prev)).getOrElse(throw SkipUpdate(prev))
+          }
+        }
+      )
+    ).fold(
+      {
+        case SkipUpdate(prev) => prev
+        case ex => throw ex
+      },
+      identity
     )
+  }
 }

--- a/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
+++ b/src/main/scala/scalafix/internal/sbt/BlockingCache.scala
@@ -7,8 +7,7 @@ import scala.util.Try
 /** A basic thread-safe cache without any eviction. */
 class BlockingCache[K, V] {
 
-  // Number of keys is expected to be very small so the global lock should not be a bottleneck
-  private val underlying = ju.Collections.synchronizedMap(new ju.HashMap[K, V])
+  private val underlying = new ju.concurrent.ConcurrentHashMap[K, V]
 
   private case class SkipUpdate(prev: V) extends Exception
 

--- a/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -10,8 +10,6 @@ import sbt.complete.DefaultParsers._
 
 class ScalafixCompletions(
     workingDirectory: Path,
-    // Unfortunately, local rules will not show up as completions in the parser, as that parser can only
-    // depend on settings, while local rules classpath must be looked up via tasks
     loadedRules: () => Seq[ScalafixRule],
     terminalWidth: Option[Int],
     allowedTargetFilesPrefixes: Seq[Path], // Nil means all values are valid

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -146,6 +146,7 @@ object ScalafixPlugin extends AutoPlugin {
             scalafixInterfaceCache.value,
             scalafixScalaBinaryVersion.value,
             toolClasspath = Arg.ToolClasspath(
+              // Local rules classpath must be looked up via tasks so they can't appear in completions
               Nil,
               scalafixDependencies.value,
               // scalafixSbtResolversAsCoursierRepositories can't be

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -29,12 +29,16 @@ class SbtCompletionsSuite extends AnyFunSuite {
   }
   val mainArgs =
     ScalafixInterface(
+      new BlockingCache(),
       "2.12",
-      Seq(exampleDependency),
-      Seq(
-        Repository.central,
-        MavenRepository.of(
-          "https://oss.sonatype.org/content/repositories/snapshots"
+      Arg.ToolClasspath(
+        Nil,
+        Seq(exampleDependency),
+        Seq(
+          Repository.central,
+          MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/snapshots"
+          )
         )
       ),
       ScalafixInterface.defaultLogger,

--- a/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/SbtCompletionsSuite.scala
@@ -28,19 +28,18 @@ class SbtCompletionsSuite extends AnyFunSuite {
     "ch.epfl.scala" %% "example-scalafix-rule" % "2.0.0-RC1"
   }
   val mainArgs =
-    ScalafixInterface
-      .fromToolClasspath(
-        "2.12",
-        Seq(exampleDependency),
-        Seq(
-          Repository.central,
-          MavenRepository.of(
-            "https://oss.sonatype.org/content/repositories/snapshots"
-          )
-        ),
-        ScalafixInterface.defaultLogger,
-        new ScalafixLogger(ScalafixInterface.defaultLogger)
-      )()
+    ScalafixInterface(
+      "2.12",
+      Seq(exampleDependency),
+      Seq(
+        Repository.central,
+        MavenRepository.of(
+          "https://oss.sonatype.org/content/repositories/snapshots"
+        )
+      ),
+      ScalafixInterface.defaultLogger,
+      new ScalafixLogger(ScalafixInterface.defaultLogger)
+    )
   val loadedRules = mainArgs.availableRules.toList
 
   val defaultParser = new ScalafixCompletions(

--- a/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
@@ -31,19 +31,18 @@ class ScalafixAPISuite extends AnyFunSuite {
     assume(!Properties.isWin)
     val baos = new ByteArrayOutputStream()
     val logger = ConsoleLogger(new PrintStream(baos))
-    val interface = ScalafixInterface
-      .fromToolClasspath(
-        "2.12",
-        List("ch.epfl.scala" %% "example-scalafix-rule" % "4.0.0"),
-        Seq(
-          Repository.central,
-          MavenRepository.of(
-            "https://oss.sonatype.org/content/repositories/snapshots"
-          )
-        ),
-        logger,
-        new ScalafixLogger(logger)
-      )()
+    val interface = ScalafixInterface(
+      "2.12",
+      List("ch.epfl.scala" %% "example-scalafix-rule" % "4.0.0"),
+      Seq(
+        Repository.central,
+        MavenRepository.of(
+          "https://oss.sonatype.org/content/repositories/snapshots"
+        )
+      ),
+      logger,
+      new ScalafixLogger(logger)
+    )
       .withArgs(Arg.PrintStream(new PrintStream(baos)))
     val tmp = Files.createTempFile("scalafix", "Tmp.scala")
     tmp.toFile.deleteOnExit()

--- a/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
+++ b/src/test/scala/scalafix/internal/sbt/ScalafixAPISuite.scala
@@ -32,12 +32,16 @@ class ScalafixAPISuite extends AnyFunSuite {
     val baos = new ByteArrayOutputStream()
     val logger = ConsoleLogger(new PrintStream(baos))
     val interface = ScalafixInterface(
+      new BlockingCache(),
       "2.12",
-      List("ch.epfl.scala" %% "example-scalafix-rule" % "4.0.0"),
-      Seq(
-        Repository.central,
-        MavenRepository.of(
-          "https://oss.sonatype.org/content/repositories/snapshots"
+      Arg.ToolClasspath(
+        Nil,
+        List("ch.epfl.scala" %% "example-scalafix-rule" % "4.0.0"),
+        Seq(
+          Repository.central,
+          MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/snapshots"
+          )
         )
       ),
       logger,


### PR DESCRIPTION
[Code review](https://github.com/scalacenter/sbt-scalafix/pull/404#discussion_r1566477171) showed that we have several types of memoization since https://github.com/scalacenter/sbt-scalafix/pull/380. It turns that we have actually 3 different types of caching at the moment:
1. [a basic `LazyValue` memoizer](https://github.com/scalacenter/sbt-scalafix/commit/4dbaf1ece9a67ab686cf5c4e12483298996005de), effectively useless since https://github.com/scalacenter/sbt-scalafix/pull/380 given how it's used
1. [a companion-object-bound cache](https://github.com/scalacenter/sbt-scalafix/pull/380), to amortize the cost of repeated invocations
1. [a task-bound cache](https://github.com/scalacenter/sbt-scalafix/commit/89cfd04629a6c67d3110e073c1c9948675c85a37), to amortize a single invocation across several projects/configs with local rules and/or an adhoc CLI `dependency:` rule

This PR is folding these 3 caches into a single setting-bound one, to (hopefully) make the code more maintainable, as well as improving the UX for developers using local rules:
- the CPU usage should be lower when repeating `scalafix` invocations (particularly benefiting users of `scalafixOnCompile`) thanks to the warm classloader for local rules
- permanent memory consumption should be insignificantly higher (to persist the custom tool classpath classloader)