### PR TITLE
avoid full (re)compilation after cold scalafix invocations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ scriptedSbt := {
   if (jdk >= 21)
     "1.9.0" // first release that supports JDK21
   else
-    (pluginCrossBuild / sbtVersion).value
+    "1.3.3" // get https://github.com/sbt/sbt/issues/1673 to avoid race conditions
 }
 
 libraryDependencies += compilerPlugin(scalafixSemanticdb)

--- a/src/sbt-test/sbt-scalafix/relax-scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-scalafix/relax-scalacOptions/build.sbt
@@ -1,14 +1,8 @@
 val V = _root_.scalafix.sbt.BuildInfo
 
 addCompilerPlugin(scalafixSemanticdb)
-scalacOptions ++= Seq("-Yrangepos")
-
+scalacOptions ++= Seq("-Yrangepos", "-Ywarn-unused")
 scalaVersion := V.scala212
-scalacOptions ++= Seq(
-  // generate errors on unused imports
-  "-Xfatal-warnings",
-  "-Ywarn-unused"
-)
 Compile / compile / scalacOptions ++= Seq(
   // generate errors on procedure syntax
   "-Wconf:cat=deprecation:e",
@@ -36,11 +30,6 @@ TaskKey[Unit]("checkLastCompilationCached") := {
     lines.foreach(line => str.log.error(line))
     throw new RuntimeException("last compilation was not fully cached")
   }
-}
-
-TaskKey[Unit]("checkZincAnalysisPresent") := {
-  val isPresent = (Compile / previousCompile).value.analysis.isPresent()
-  assert(isPresent, "zinc analysis not found")
 }
 
 // https://github.com/sbt/sbt/commit/dbb47b3ce822ff7ec25881dadd71a3b29e202273

--- a/src/sbt-test/sbt-scalafix/relax-scalacOptions/test
+++ b/src/sbt-test/sbt-scalafix/relax-scalacOptions/test
@@ -1,22 +1,45 @@
-# we have 2 fatal warnings preventing compilation
+# when the build does not contain any flag relaxed on scalafix invocation
+# check that regular compilation benefits froma prior direct scalafix invocation ...
+-> scalafix --check RemoveUnused
+-> checkLastCompilationCached
+> compile
+> checkLastCompilationCached
+
+# ... and indirect scalafix invocation
+> clean
+> test:scalafix --check RemoveUnused
+-> checkLastCompilationCached
+> compile
+> checkLastCompilationCached
+
+# we now have 2 fatal warnings preventing compilation
+> set scalacOptions ++= Seq("-Xfatal-warnings")
 -> compile
 
 # ensure that a semantic rule can be ran despite warnings, to fix one of the warning
-> scalafixAll RemoveUnused
+> scalafix RemoveUnused
 
-# but that the zinc analysis file has not been persisted, otherwise the run with relax scalacOptions would
-# cause the next compile to be full (non-incremental) no matter if there was a previous successful compilation
--> checkZincAnalysisPresent
+# confirm that the rule was applied and that triggered compilation is cached once the updated file recompiled
+> scalafix --check RemoveUnused
+-> checkLastCompilationCached
+> scalafix --check RemoveUnused
+> checkLastCompilationCached
 
 # and that -Xfatal-warnings remains honored for regular compilation
 -> compile
 
-# confirm that compilation succeeds after fixing the last warning
+# confirm that regular compilation succeeds after fixing the last warning
 > scalafix ProcedureSyntax
 > compile
-> checkZincAnalysisPresent
 
-# check that there is no recompilation when running a semantic rule after a successful compilation
--> checkLastCompilationCached
-> scalafixAll RemoveUnused
+# check that regular compilation is cached as usual
+> compile
+> checkLastCompilationCached
+
+# check that there is no recompilation when running a semantic rule after a regular compilation ...
+> scalafix RemoveUnused
+> checkLastCompilationCached
+
+# nor when compiling after running a semantic rule
+> compile
 > checkLastCompilationCached


### PR DESCRIPTION
Follow-up of https://twitter.com/channingwalton/status/1778119590486118908 which puts the finger on a behavior that can be very irritating in large builds

> TIL [#scala](https://twitter.com/hashtag/scala?src=hashtag_click) [#protip](https://twitter.com/hashtag/protip?src=hashtag_click) Scalafix. 
> 
> If you put “scalafix —check” before other steps in your sbt build, your code might get compiled twice. 
> 
> Put it after compilation steps to avoid the problem.

This revisits https://github.com/scalacenter/sbt-scalafix/pull/152, leveraging `scalafixInvoked` (which has the same semantics as the `scalafixRunExplicitly` mentioned in the old PR but didn't cause any issue for [3 years](https://github.com/scalacenter/sbt-scalafix/pull/196)) in order to trigger a regular `compile` from `scalafix` and thus store zinc analysis to benefit later compilations.