### PR TITLE
bump sbt-ci-release to fix JDK8 support

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers ++= Resolver.sonatypeOssRepos("public")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 Compile / unmanagedSourceDirectories ++= {


### PR DESCRIPTION
Follows https://github.com/scalacenter/sbt-scalafix/pull/428
See https://github.com/xerial/sbt-sonatype/issues/507

The regression is not visible on master  as the new client is apparently not used for OSS snapshots.