### PR TITLE
fix Scala 2.11 detection & use same instance across patch releases

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -126,7 +126,7 @@ object ScalafixInterface {
 
   type Cache = BlockingCache[
     (
-        String, // scalafixScalaBinaryVersion
+        String, // scalafixScalaMajorMinorVersion
         Option[Arg.ToolClasspath]
     ),
     (
@@ -139,7 +139,7 @@ object ScalafixInterface {
 
   def apply(
       cache: Cache,
-      scalafixScalaBinaryVersion: String,
+      scalafixScalaMajorMinorVersion: String,
       toolClasspath: Arg.ToolClasspath,
       logger: Logger,
       callback: ScalafixMainCallback
@@ -150,7 +150,7 @@ object ScalafixInterface {
     // shared as much as possible.
     val (buildinRulesInterface, _) = cache.compute(
       (
-        scalafixScalaBinaryVersion,
+        scalafixScalaMajorMinorVersion,
         None
       ),
       {
@@ -159,14 +159,14 @@ object ScalafixInterface {
           None
         case None =>
           // cache miss, resolve scalafix artifacts and classload them
-          if (scalafixScalaBinaryVersion == "2.11")
+          if (scalafixScalaMajorMinorVersion == "2.11")
             logger.error(
               "Scala 2.11 is no longer supported. Please downgrade to the final version supporting " +
                 "it: sbt-scalafix 0.10.4."
             )
           val scalafixArguments = ScalafixAPI
             .fetchAndClassloadInstance(
-              scalafixScalaBinaryVersion,
+              scalafixScalaMajorMinorVersion,
               toolClasspath.repositories.asJava
             )
             .newArguments()
@@ -197,7 +197,7 @@ object ScalafixInterface {
 
     val (toolClasspathInterface, _) = cache.compute(
       (
-        scalafixScalaBinaryVersion,
+        scalafixScalaMajorMinorVersion,
         Some(toolClasspath)
       ),
       {

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -327,7 +327,7 @@ object ScalafixPlugin extends AutoPlugin {
       shell: ShellArgs,
       projectDepsExternal: Seq[ModuleID],
       projectDepsInternal: Seq[File],
-      projectScalafixScalaBinaryVersion: String,
+      projectScalaMajorMinorVersion: String,
       projectScalafixDependencies: Seq[ModuleID],
       buildAllResolvers: Seq[Repository],
       buildScalafixMainCallback: ScalafixMainCallback,
@@ -364,7 +364,7 @@ object ScalafixPlugin extends AutoPlugin {
 
     val interface = ScalafixInterface(
       cache = buildScalafixInterfaceCache,
-      scalafixScalaMajorMinorVersion = projectScalafixScalaBinaryVersion,
+      scalafixScalaMajorMinorVersion = projectScalaMajorMinorVersion,
       toolClasspath = toolClasspath,
       logger = ScalafixInterface.defaultLogger,
       callback = buildScalafixMainCallback

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -265,7 +265,8 @@ object ScalafixPlugin extends AutoPlugin {
     },
     ivyConfigurations += ScalafixConfig,
     scalafixAll := scalafixAllInputTask.evaluated,
-    (scalafixScalaBinaryVersion: @nowarn) := scalaVersion.value
+    (scalafixScalaBinaryVersion: @nowarn) :=
+      scalaVersion.value.split('.').take(2).mkString(".")
   )
 
   override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
@@ -363,7 +364,7 @@ object ScalafixPlugin extends AutoPlugin {
 
     val interface = ScalafixInterface(
       cache = buildScalafixInterfaceCache,
-      scalafixScalaBinaryVersion = projectScalafixScalaBinaryVersion,
+      scalafixScalaMajorMinorVersion = projectScalafixScalaBinaryVersion,
       toolClasspath = toolClasspath,
       logger = ScalafixInterface.defaultLogger,
       callback = buildScalafixMainCallback


### PR DESCRIPTION
Fix regression introduced in https://github.com/scalacenter/sbt-scalafix/commit/9ad48bbee83f56696ee9e6b645b21fdea50c6313: sbt-scalafix wouldn't catch usage of Scala 2.11, resulting in a non-actionnable error message.