### PR TITLE
evict cached Scalafix instances under memory pressure

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
+++ b/src/main/scala/scalafix/internal/sbt/ScalafixInterface.scala
@@ -154,9 +154,9 @@ object ScalafixInterface {
         None
       ),
       {
-        case Some(_) =>
+        case Some(v) =>
           // cache hit, don't update
-          None
+          v
         case None =>
           // cache miss, resolve scalafix artifacts and classload them
           if (scalafixScalaMajorMinorVersion == "2.11")
@@ -181,11 +181,9 @@ object ScalafixInterface {
             )
           )
 
-          Some(
-            (
-              new ScalafixInterface(scalafixArguments).withArgs(printStream),
-              Nil
-            )
+          (
+            new ScalafixInterface(scalafixArguments).withArgs(printStream),
+            Nil
           )
       }
     )
@@ -201,16 +199,14 @@ object ScalafixInterface {
         Some(toolClasspath)
       ),
       {
-        case Some((_, oldStamps)) if (currentStamps == oldStamps) =>
+        case Some(v @ (_, oldStamps)) if (currentStamps == oldStamps) =>
           // cache hit, don't update
-          None
+          v
         case _ =>
           // cache miss or stale stamps, resolve custom rules artifacts and classload them
-          Some(
-            (
-              buildinRulesInterface.withArgs(toolClasspath),
-              currentStamps
-            )
+          (
+            buildinRulesInterface.withArgs(toolClasspath),
+            currentStamps
           )
       }
     )


### PR DESCRIPTION
Scalafix instances can be memory-consuming (PrintStream's static 8k BufferedWriter allocations are wasteful and hard to remove for example), so this allow eviction in case of memory pressure.

To compensate for the added complexity, the implementation was simplified.
* Values are now always updated (even if they haven't changed). This probably does not change much performance-wise, as we are trading throwing an exception (costly) against a SoftReference instanciation and the update in the low-cardinality ConcurrentHashMap.
* SAM conversion is used now that sbt 0.13 / Scala 2.11 are no longer supported.

