### PR TITLE
Enhance error message when SemanticDB scalac plugin can't be found

### DIFF
--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -250,11 +250,12 @@ object ScalafixPlugin extends AutoPlugin {
               resolveException.failed.headOption match {
                 case Some(SemanticdbScalac(rev)) =>
                   val scalaV = scalaVersion.value
-                  val msg = s"The SemanticDB scalac plugin version ${rev} set up " +
-                    "via `semanticdbVersion` does follow the version recommended " +
-                    "for Scalafix, but is not supported for the outdated Scala " +
-                    s"version ${scalaV}. Please upgrade to a more recent Scala " +
-                    "patch version or uninstall sbt-scalafix."
+                  val msg =
+                    s"The SemanticDB scalac plugin version ${rev} set up " +
+                      "via `semanticdbVersion` does follow the version recommended " +
+                      "for Scalafix, but is not supported for the given Scala " +
+                      s"version ${scalaV}. Please consider upgrading to a more recent version " +
+                      "of sbt-scalafix and/or Scala, or uninstalling sbt-scalafix plugin."
                   throw inc.copy(message = Some(msg))
                 case _ =>
               }

--- a/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/build.sbt
+++ b/src/sbt-test/sbt-scalafix/unavailable-semanticdb-scalac/build.sbt
@@ -19,7 +19,7 @@ checkLogs := {
   assert(
     logLines.exists(
       _.contains(
-        "Please upgrade to a more recent Scala patch version or uninstall sbt-scalafix"
+        "Please consider upgrading to a more recent version of sbt-scalafix and/or Scala, or uninstalling sbt-scalafix plugin"
       )
     )
   )


### PR DESCRIPTION
Hey there! Recently, I've been upgrading some dependencies of one project and accidentally got this error message in SBT:

> The SemanticDB scalac plugin version 4.9.3 set up via `semanticdbVersion` does follow the version recommended for Scalafix, but is not supported for the outdated Scala version 2.13.16. Please upgrade to a more recent Scala patch version or uninstall sbt-scalafix.

Honestly, it's a bit confusing since Scala 2.13.16 is the most recent version of the 2.13 series. What I actually had to do was update the sbt-scalafix version to the latest one.

So, here's the enhancement of that error message. 
