### PR TITLE
Revert "Update sbt-ci-release to 1.11.0"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers ++= Resolver.sonatypeOssRepos("public")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
 
 // dogfooding
 Compile / unmanagedSourceDirectories ++= {


### PR DESCRIPTION
Reverts scalacenter/sbt-scalafix#489 until the`ch.epfl.scala` namespace is [migrated to Central Portal](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/) 