### PR TITLE
improve semanticdb not found error message

### DIFF
--- a/src/main/scala/scalafix/internal/sbt/SemanticRuleValidator.scala
+++ b/src/main/scala/scalafix/internal/sbt/SemanticRuleValidator.scala
@@ -31,11 +31,11 @@ class SemanticRuleValidator(ifNotFound: SemanticdbNotFound) {
 }
 
 class SemanticdbNotFound(
-    ruleNames: Seq[String],
+    semanticRuleNames: Seq[String],
     scalaVersion: String
 ) {
   def message: String = {
-    val names = ruleNames.mkString(", ")
+    val names = semanticRuleNames.mkString(", ")
 
     s"""|The scalac compiler should produce semanticdb files to run semantic rules like $names.
       |To fix this problem for this sbt shell session, run `scalafixEnable` and try again.

--- a/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -495,10 +495,10 @@ object ScalafixPlugin extends AutoPlugin {
             Arg.ParsedArgs(shell.extra)
           )
         val rulesThatWillRun = mainInterface.rulesThatWillRun()
-        val isSemantic = rulesThatWillRun.exists(_.kind().isSemantic)
-        if (isSemantic) {
-          val names = rulesThatWillRun.map(_.name())
-          scalafixSemantic(names, mainInterface, shell, config)
+        val semanticRules = rulesThatWillRun.filter(_.kind().isSemantic)
+        if (semanticRules.nonEmpty) {
+          val semanticRuleNames = semanticRules.map(_.name())
+          scalafixSemantic(semanticRuleNames, mainInterface, shell, config)
         } else {
           scalafixSyntactic(mainInterface, shell, config)
         }
@@ -528,7 +528,7 @@ object ScalafixPlugin extends AutoPlugin {
     }
 
   private def scalafixSemantic(
-      ruleNames: Seq[String],
+      semanticRuleNames: Seq[String],
       mainArgs: ScalafixInterface,
       shellArgs: ShellArgs,
       config: ConfigKey
@@ -540,7 +540,7 @@ object ScalafixPlugin extends AutoPlugin {
       val files = filesToFix(shellArgs, config).value
       val scalacOpts = (config / compile / scalacOptions).value
       val errors = new SemanticRuleValidator(
-        new SemanticdbNotFound(ruleNames, scalaVersion.value)
+        new SemanticdbNotFound(semanticRuleNames, scalaVersion.value)
       ).findErrors(files, dependencies, scalacOpts, mainArgs)
       if (errors.isEmpty) {
         val task = Def.task {


### PR DESCRIPTION
https://github.com/scalacenter/sbt-scalafix/blob/f04ca84283693ed0a2970226d46e36d9d03ae881/src/main/scala/scalafix/internal/sbt/SemanticRuleValidator.scala#L38-L40

before: all rule names. `SyntacticRule` and `SemanticRule`
after: show only `SemanticRule` names

