### PR TITLE
Upgrades org.eclipse.jgit to the latest version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   def scalafixVersion: String = "0.14.3"
 
   val all = List(
-    "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.3.202401111512-r",
+    "org.eclipse.jgit" % "org.eclipse.jgit" % "7.3.0.202506031305-r",
     "ch.epfl.scala" % "scalafix-interfaces" % scalafixVersion,
     "io.get-coursier" % "interface" % "1.0.28",
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0"


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/2270

Upgrades jgit to to vulnerability:
https://ossindex.sonatype.org/vuln/CVE-2025-4949
